### PR TITLE
Correct the capitalization of TYPE=Bridge

### DIFF
--- a/templates/bridge_RedHat.j2
+++ b/templates/bridge_RedHat.j2
@@ -22,7 +22,7 @@ GATEWAY={{ item.gateway }}
 
 {% if item.bootproto == 'dhcp' %}
 DEVICE={{ item.device }}
-TYPE=bridge
+TYPE=Bridge
 BOOTPROTO=dhcp
 {% if item.stp is defined %}
 STP={{ item.stp }}


### PR DESCRIPTION
Fixes the error described here:
http://www.itechlounge.net/2013/01/linux-device-br0-does-not-seem-to-be-present-delaying-initialization/
