### PR TITLE
Added VLAN support for RHEL based systems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.vagrant/

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ machines. The role can be used to configure:
 - Ethernet interfaces
 - Bridge interfaces
 - Bonded interfaces
+- VLAN tagged interfaces
 - Network routes
 
 Requirements
@@ -33,6 +34,9 @@ them are as follows:
 
     # The list of bonded interfaces to be added to the system
     network_bond_interfaces: []
+
+    # The list of vlan interfaces to be added to the system
+    network_vlan_interfaces: []
 
 Note: The values for the list are listed in the examples below.
 
@@ -109,7 +113,24 @@ address obtained via DHCP.
               bond_miimon: 100
               bond_slaves: [eth1, eth2]
 
-5) All the above examples show how to configure a single host, The below
+5) Configure a VLAN interface with the vlan tag 2 for an ethernet interface
+
+    - hosts: myhost
+      roles:
+        - role: network
+          network_ether_interfaces:
+           - device: eth1
+             bootproto: static
+             address: 192.168.10.18
+             netmask: 255.255.255.0
+             gateway: 192.168.10.1
+          network_vlan_interfaces:
+	   - device: eth1.2
+	     bootproto: static
+	     address: 192.168.20.18
+	     netmask: 255.255.255.0
+
+6) All the above examples show how to configure a single host, The below
 example shows how to define your network configurations for all your machines.
 
 Assume your host inventory is as follows:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,40 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure(2) do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://atlas.hashicorp.com/search.
+  config.vm.box = "ubuntu/trusty64"
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  # config.vm.box_check_update = false
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP. Don't configure, let the network_interface role configure
+  config.vm.network "private_network", ip: "192.168.33.10", auto_config: false
+
+  # Make sure VLAN tagging works on VirtualBox VMs
+  config.vm.provider "virtualbox" do |vb|
+    # Set the private network nic to be AMD PCI, not Intel, so that VLAN
+    # tagging works (eth1, eth0 is reserved for Vagrant work, don't tweak)
+    # VBoxManage modifyvm $box --nictype1 virtio
+#    vb.customize = ["modifyvm", :id, "--nictype2", "virtio"]
+
+    # Customize the amount of memory on the VM:
+    vb.memory = "1024"
+  end
+
+  config.vm.provision "ansible" do |ansible|
+    ansible.playbook = "vagrant-playbook.yml"
+  end
+end

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+roles_path = ../

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -81,7 +81,7 @@
 - name: Create the network configuration file for vlan devices
   template: src=ethernet_{{ ansible_os_family }}.j2 dest={{ net_path }}/ifcfg-{{ item.device }}
   with_items: network_vlan_interfaces
-  when: network_ether_vlan is defined
+  when: network_vlan_interfaces is defined
   register: vlan_result
 
 - name: Write configuration files for rhel route configuration with vlan

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -43,33 +43,6 @@
   with_items: ether_result.results
   when: ether_result is defined and item.changed
 
-- name: Create the network configuration file for bridge devices
-  template: src=bridge_{{ ansible_os_family }}.j2 dest={{ net_path }}/ifcfg-{{ item.device }}
-  with_items: network_bridge_interfaces
-  when: network_bridge_interfaces is defined 
-  register: bridge_result
-
-- name: Write configuration files for rhel route configuration
-  template: src=route_{{ ansible_os_family }}.j2 dest={{ net_path }}/route-{{ item.device }} 
-  with_items: network_bridge_interfaces
-  when: network_bridge_interfaces is defined and item.route is defined and ansible_os_family == 'RedHat'
-
-- shell: ifdown {{ item.item.device }}; ifup {{ item.item.device }}
-  with_items: bridge_result.results
-  when: bridge_result is defined and item.changed
- 
-- name: Create the network configuration file for port on the bridge devices
-  template: src=bridge_port_{{ ansible_os_family }}.j2 dest={{ net_path }}/ifcfg-{{ item.1 }}
-  with_subelements: 
-   - network_bridge_interfaces
-   - ports
-  when: network_bridge_interfaces is defined 
-  register: bridge_port_result
-
-- shell: ifdown {{ item.item.1 }}; ifup {{ item.item.1 }}
-  with_items: bridge_port_result.results
-  when: bridge_port_result is defined and item.changed
-
 - name: Create the network configuration file for bond devices
   template: src=bond_{{ ansible_os_family }}.j2 dest={{ net_path }}/ifcfg-{{ item.device }}
   with_items: network_bond_interfaces
@@ -104,3 +77,45 @@
 - shell: ifdown {{ item.item.device }}; ifup {{ item.item.device }}
   with_items: bond_result.results
   when: bond_result is defined and item.changed and ansible_os_family == 'RedHat'
+
+- name: Create the network configuration file for vlan devices
+  template: src=ethernet_{{ ansible_os_family }}.j2 dest={{ net_path }}/ifcfg-{{ item.device }}
+  with_items: network_vlan_interfaces
+  when: network_ether_vlan is defined
+  register: vlan_result
+
+- name: Write configuration files for rhel route configuration with vlan
+  template: src=route_{{ ansible_os_family }}.j2 dest={{ net_path }}/route-{{ item.device }}
+  with_items: network_vlan_interfaces
+  when: network_ether_interfaces is defined and item.route is defined and ansible_os_family == 'RedHat'
+
+- shell: ifdown {{ item.item.device }}; ifup {{ item.item.device }}
+  with_items: vlan_result.results
+  when: vlan_result is defined and item.changed
+
+- name: Create the network configuration file for bridge devices
+  template: src=bridge_{{ ansible_os_family }}.j2 dest={{ net_path }}/ifcfg-{{ item.device }}
+  with_items: network_bridge_interfaces
+  when: network_bridge_interfaces is defined
+  register: bridge_result
+
+- name: Write configuration files for rhel route configuration
+  template: src=route_{{ ansible_os_family }}.j2 dest={{ net_path }}/route-{{ item.device }}
+  with_items: network_bridge_interfaces
+  when: network_bridge_interfaces is defined and item.route is defined and ansible_os_family == 'RedHat'
+
+- shell: ifdown {{ item.item.device }}; ifup {{ item.item.device }}
+  with_items: bridge_result.results
+  when: bridge_result is defined and item.changed
+
+- name: Create the network configuration file for port on the bridge devices
+  template: src=bridge_port_{{ ansible_os_family }}.j2 dest={{ net_path }}/ifcfg-{{ item.1 }}
+  with_subelements:
+   - network_bridge_interfaces
+   - ports
+  when: network_bridge_interfaces is defined
+  register: bridge_port_result
+
+- shell: ifdown {{ item.item.1 }}; ifup {{ item.item.1 }}
+  with_items: bridge_port_result.results
+  when: bridge_port_result is defined and item.changed

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,7 +14,6 @@
   environment: env
   when: ansible_os_family == 'Debian'
 
-
 - name: Make sure the include line is there in interfaces file
   lineinfile: >
      regexp="^source\ \/etc\/network\/interfaces.d\/\*"
@@ -28,14 +27,20 @@
   file: path=/etc/network/interfaces.d  state=directory
   when: ansible_os_family == "Debian"
 
-- name: Create the network configuration file for ethernet devices
+- name: Create the network configuration file for ethernet devices (RedHat)
   template: src=ethernet_{{ ansible_os_family }}.j2 dest={{ net_path }}/ifcfg-{{ item.device }}
   with_items: network_ether_interfaces
-  when: network_ether_interfaces is defined
+  when: network_ether_interfaces is defined and ansible_os_family == 'RedHat'
+  register: ether_result
+
+- name: Create the network configuration file for ethernet devices (Debian)
+  template: src=ethernet_{{ ansible_os_family }}.j2 dest={{ net_path }}/{{ item.device }}.cfg
+  with_items: network_ether_interfaces
+  when: network_ether_interfaces is defined and ansible_os_family == 'Debian'
   register: ether_result
 
 - name: Write configuration files for rhel route configuration
-  template: src=route_{{ ansible_os_family }}.j2 dest={{ net_path }}/route-{{ item.device }} 
+  template: src=route_{{ ansible_os_family }}.j2 dest={{ net_path }}/route-{{ item.device }}
   with_items: network_ether_interfaces
   when: network_ether_interfaces is defined and item.route is defined and ansible_os_family == 'RedHat'
 
@@ -54,7 +59,7 @@
   when: bond_result|changed
 
 - name: Write configuration files for route configuration
-  template: src=route_{{ ansible_os_family }}.j2 dest={{ net_path }}/route-{{ item.device }} 
+  template: src=route_{{ ansible_os_family }}.j2 dest={{ net_path }}/route-{{ item.device }}
   with_items: network_bond_interfaces
   when: network_bond_interfaces is defined and item.route is defined and ansible_os_family == 'RedHat'
 
@@ -64,7 +69,7 @@
 
 - name: Create the network configuration file for slave in the bond devices
   template: src=bond_slave_{{ ansible_os_family }}.j2 dest={{ net_path }}/ifcfg-{{ item.1 }}
-  with_subelements: 
+  with_subelements:
    - network_bond_interfaces
    - bond_slaves
   when: network_bond_interfaces is defined
@@ -78,16 +83,26 @@
   with_items: bond_result.results
   when: bond_result is defined and item.changed and ansible_os_family == 'RedHat'
 
-- name: Create the network configuration file for vlan devices
+- name: Create the network configuration file for vlan devices (Debian)
+  template: src=ethernet_{{ ansible_os_family }}.j2 dest={{ net_path }}/{{ item.device }}.cfg
+  with_items: network_vlan_interfaces
+  when: network_vlan_interfaces is defined and ansible_os_family == 'Debian'
+  register: vlan_result
+
+- name: Create the network configuration file for vlan devices (RedHat)
   template: src=ethernet_{{ ansible_os_family }}.j2 dest={{ net_path }}/ifcfg-{{ item.device }}
   with_items: network_vlan_interfaces
-  when: network_vlan_interfaces is defined
+  when: network_vlan_interfaces is defined and ansible_os_family == 'RedHat'
   register: vlan_result
 
 - name: Write configuration files for rhel route configuration with vlan
   template: src=route_{{ ansible_os_family }}.j2 dest={{ net_path }}/route-{{ item.device }}
   with_items: network_vlan_interfaces
   when: network_ether_interfaces is defined and item.route is defined and ansible_os_family == 'RedHat'
+
+- name: Make sure the vlan/802.1q module is loaded
+  modprobe: name=8021q state=present
+  when: vlan_result|changed and ansible_os_family == 'Debian'
 
 - shell: ifdown {{ item.item.device }}; ifup {{ item.item.device }}
   with_items: vlan_result.results

--- a/templates/ethernet_RedHat.j2
+++ b/templates/ethernet_RedHat.j2
@@ -15,7 +15,7 @@ NETMASK={{ item.netmask }}
 GATEWAY={{ item.gateway }}
 {% endif %}
 {% if item.vlan is defined %}
-VLAN={{ item.vlan }}
+VLAN=yes
 {% endif %}
 {% endif %}
 

--- a/templates/ethernet_RedHat.j2
+++ b/templates/ethernet_RedHat.j2
@@ -14,6 +14,9 @@ NETMASK={{ item.netmask }}
 {% if item.gateway is defined %}
 GATEWAY={{ item.gateway }}
 {% endif %}
+{% if item.vlan is defined %}
+VLAN={{ item.vlan }}
+{% endif %}
 {% endif %}
 
 {% if item.bootproto == 'dhcp' %}

--- a/vagrant-playbook.yml
+++ b/vagrant-playbook.yml
@@ -1,0 +1,17 @@
+---
+- hosts: all
+  user: vagrant
+  sudo: True
+  roles:
+    - role: network_interface
+      network_ether_interfaces:
+        - device: eth1
+          bootproto: static
+          address: 192.168.33.10
+          netmask: 255.255.255.0
+          gateway: 192.168.33.1
+      network_vlan_interfaces:
+        - device: eth1.2
+          bootproto: static
+          address: 192.168.20.18
+          netmask: 255.255.255.0

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -4,5 +4,6 @@ network_pkgs:
   - python-selinux
   - bridge-utils
   - ifenslave-2.6
+  - vlan
 
 net_path: "/etc/network/interfaces.d"


### PR DESCRIPTION
Added support for VLAN tagged interfaces on RHEL based systems in the
ethernet template. Modified order of tasks so that bridges come up last.
The logic being, bonded interfaces can be in bridges.

This commit only does the VLAN stuff for RHEL based systems, not Debian based systems. So if this is accepted, Debian support should probably be considered.
