### PR TITLE
add support for resolv.conf

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,6 +28,11 @@
   file: path=/etc/network/interfaces.d  state=directory
   when: ansible_os_family == "Debian"
 
+- name: Create resolv.conf
+  template: src=resolv.conf.j2 dest=/etc/resolv.conf
+  with_items: "{{ dns_servers  }}"
+  when: dns_servers is defined
+
 - name: Create the network configuration file for ethernet devices
   template: src=ethernet_{{ ansible_os_family }}.j2 dest={{ net_path }}/ifcfg-{{ item.device }}
   with_items: network_ether_interfaces

--- a/templates/resolv.conf.j2
+++ b/templates/resolv.conf.j2
@@ -1,0 +1,15 @@
+# keep in mind to disable NetworkManager or else this will be overwritten, possibly disabling DNS
+
+{% if dns_servers is defined %}
+{% for dns in dns_servers %}
+nameserver {{ dns }}
+{% endfor %}
+{% endif %}
+
+{% if dns_search is defined %}
+search {{ dns_search }}
+{% endif %}
+
+{% if dns_domain is defined %}
+domain {{ dns_domain }}
+{% endif %}


### PR DESCRIPTION
Hi Benno,

Thank you for your Ansible role to setup network connections for both Debian and Redhat, it's quite useful to me :)
I've added a small addition to setup the resolv.conf for DNS.

Let me know if this is something you'd like to add.
If you want I can also take care of the Ansible warnings in a separate PR.

Regards,

Barry
