### PR TITLE
Ignore bond interfaces when reapplying interfaces

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,51 @@
+language: python
+
+sudo: required
+dist: trusty
+group: edge
+
+services:
+  - docker
+
+matrix:
+  fast_finish: true
+
+env:
+  - IMAGE_BUILD_PLATFORM=stable-centos7
+  - IMAGE_BUILD_PLATFORM=devel-centos7
+install:
+  - npm install -g validate-dockerfile
+
+before_script:
+  # TESTDIR = Where the stable-centos/Dockerfile is located
+  - export TESTDIR=tests
+  # ROLETOTEST = The name of this repo
+  - export ROLETOTEST=$(basename $(pwd))
+  - export COMMIT=${TRAVIS_COMMIT::8}
+  # The tag we assign the docker image we build with the Dockerfile
+  - export REPO=csc/ansible
+  # https://www.npmjs.com/package/validate-dockerfile - validate the Dockerfile
+  - docklint ${TESTDIR}/${IMAGE_BUILD_PLATFORM}/Dockerfile
+  # Build the image
+  - docker build -t ${REPO}:${IMAGE_BUILD_PLATFORM} ${TESTDIR}/${IMAGE_BUILD_PLATFORM}/
+  # Launch the container
+  - docker run --privileged -d -ti -e "container=docker"  -v `pwd`:/$ROLETOTEST -v /sys/fs/cgroup:/sys/fs/cgroup  ${REPO}:${IMAGE_BUILD_PLATFORM}  /usr/sbin/init
+  - DOCKER_CONTAINER_ID=$(docker ps | grep ${IMAGE_BUILD_PLATFORM} | awk '{print $1}')
+  - docker logs $DOCKER_CONTAINER_ID
+script:
+  # Testing of this ansible-role:
+  - docker exec -ti $DOCKER_CONTAINER_ID /bin/sh -c "/$ROLETOTEST/tests/test-in-docker-image.sh"
+after_script:
+  - >
+    docker exec -ti $DOCKER_CONTAINER_ID /bin/sh -c 'echo -ne "------\nEND ANSIBLE TESTS\n------\nSystemD Units:\n------\n";
+       systemctl --no-pager --all --full status ;
+       echo -ne "------\nJournalD Logs:\n------\n" ;
+       sudo journalctl --catalog --all --full --no-pager'
+  - docker exec -ti $DOCKER_CONTAINER_ID /bin/sh -c 'tree /ansible*'
+  - docker exec -ti $DOCKER_CONTAINER_ID /bin/sh -c 'tree /etc'
+  - docker ps -a
+  - docker stop $DOCKER_CONTAINER_ID
+  - docker rm -v $DOCKER_CONTAINER_ID
+
+notifications:
+  email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ matrix:
 env:
   - IMAGE_BUILD_PLATFORM=stable-centos7
   - IMAGE_BUILD_PLATFORM=devel-centos7
+  - IMAGE_BUILD_PLATFORM=ansible-min-version-centos7
+
 install:
   - npm install -g validate-dockerfile
 
@@ -28,21 +30,26 @@ before_script:
   - docklint ${TESTDIR}/${IMAGE_BUILD_PLATFORM}/Dockerfile
   # Build the image
   - docker build -t ${REPO}:${IMAGE_BUILD_PLATFORM} ${TESTDIR}/${IMAGE_BUILD_PLATFORM}/
+  # Find out min_ansible_version
+  - export MIN_ANSIBLE_VERSION=$(grep min_ansible_version meta/main.yml|cut -d ':' -f2|xargs)
+  - echo "INFO min_ansible_version $MIN_ANSIBLE_VERSION"
   # Launch the container
   - docker run --privileged -d -ti -e "container=docker"  -v `pwd`:/$ROLETOTEST -v /sys/fs/cgroup:/sys/fs/cgroup  ${REPO}:${IMAGE_BUILD_PLATFORM}  /usr/sbin/init
   - DOCKER_CONTAINER_ID=$(docker ps | grep ${IMAGE_BUILD_PLATFORM} | awk '{print $1}')
+  # If ansible-min-version install it with pip
+  - if [ "$IMAGE_BUILD_PLATFORM" == "ansible-min-version-centos7" ]; then docker exec -ti $DOCKER_CONTAINER_ID /bin/sh -c "/usr/bin/pip install ansible==$MIN_ANSIBLE_VERSION"; fi
   - docker logs $DOCKER_CONTAINER_ID
 script:
   # Testing of this ansible-role:
   - docker exec -ti $DOCKER_CONTAINER_ID /bin/sh -c "/$ROLETOTEST/tests/test-in-docker-image.sh"
 after_script:
+  # Print some logs and other useful information for debugging travis:
   - >
     docker exec -ti $DOCKER_CONTAINER_ID /bin/sh -c 'echo -ne "------\nEND ANSIBLE TESTS\n------\nSystemD Units:\n------\n";
        systemctl --no-pager --all --full status ;
        echo -ne "------\nJournalD Logs:\n------\n" ;
        sudo journalctl --catalog --all --full --no-pager'
   - docker exec -ti $DOCKER_CONTAINER_ID /bin/sh -c 'tree /ansible*'
-  - docker exec -ti $DOCKER_CONTAINER_ID /bin/sh -c 'tree /etc'
   - docker ps -a
   - docker stop $DOCKER_CONTAINER_ID
   - docker rm -v $DOCKER_CONTAINER_ID

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ machines. The role can be used to configure:
 - Ethernet interfaces
 - Bridge interfaces
 - Bonded interfaces
+- VLAN tagged interfaces
 - Network routes
 
 Requirements
@@ -33,6 +34,9 @@ them are as follows:
 
     # The list of bonded interfaces to be added to the system
     network_bond_interfaces: []
+
+    # The list of vlan interfaces to be added to the system
+    network_vlan_interfaces: []
 
 Note: The values for the list are listed in the examples below.
 
@@ -109,7 +113,24 @@ address obtained via DHCP.
               bond_miimon: 100
               bond_slaves: [eth1, eth2]
 
-5) All the above examples show how to configure a single host, The below
+5) Configure a VLAN interface with the vlan tag 2 for an ethernet interface
+
+    - hosts: myhost
+      roles:
+        - role: network
+          network_ether_interfaces:
+           - device: eth1
+             bootproto: static
+             address: 192.168.10.18
+             netmask: 255.255.255.0
+             gateway: 192.168.10.1
+          network_vlan_interfaces:
+	   - device: eth1.2
+	     bootproto: static
+	     address: 192.168.20.18
+	     netmask: 255.255.255.0
+
+6) All the above examples show how to configure a single host, The below
 example shows how to define your network configurations for all your machines.
 
 Assume your host inventory is as follows:

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ address obtained via DHCP.
               bond_slaves: [eth1, eth2]
 ```
 
-5) Configure a VLAN interface with the vlan tag 2 for an ethernet interface 
+5) Configure a VLAN interface with the vlan tag 2 for an ethernet interface
 and set nozeroconf to True (no 169.254.0.0/16 link local address).
 
 ```
@@ -150,8 +150,34 @@ and set nozeroconf to True (no 169.254.0.0/16 link local address).
 	            address: 192.168.20.18
 	            netmask: 255.255.255.0
 ```
+6) Configure Bond interface over vlan tagged 1001 interfaces with extra route.
+important part is define that slaves for the bond are vlan slaves
+and bond carrier detection is not using physical interface link status. This feature is extremely usable whenever one needs better utilization of physical interfaces. two physical interfaces can support 2 or more different bonded interfaces  that have different tagged vlans. This means that for example public and private networks ( 2 different tagged vlans) can be separated  to different physical interfaces for communication and in failure state, fail over to available interface. 
 
-6) All the above examples show how to configure a single host, The below
+```
+- hosts: myhost
+  roles:
+    - role: network
+      network_extra_bonding_module_options: "use_carrier=0"
+      network_bond_interfaces:
+        - device: bond-ext
+          address: 192.168.10.128
+          netmask: 255.255.255.0
+          bootproto: static
+          bond_mode: active-backup
+          onboot: "yes"
+          nm_controlled: "no"
+          mtu: 9000
+          bond_miimon: 500
+          bond_slaves: [eth1.1001, eth2.1001]
+          route:
+            - network: 192.168.222.0
+              netmask: 255.255.255.0
+              gateway: 192.168.10.1
+
+```
+
+7) All the above examples show how to configure a single host, The below
 example shows how to define your network configurations for all your machines.
 
 Assume your host inventory is as follows:
@@ -206,6 +232,7 @@ may need to have a control interface that you do *not* modify using this
 method so that Ansible has a stable connection to configure the target
 systems.
 
+
 Dependencies
 ------------
 
@@ -220,4 +247,3 @@ Author Information
 ------------------
 
 Benno Joy
-

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ machines. The role can be used to configure:
 - Bonded interfaces
 - VLAN tagged interfaces
 - Network routes
+- Bonding Kernel Module parameters
 
 Requirements
 ------------
@@ -91,13 +92,16 @@ define static routes and a gateway.
 Note: Routes can also be added for this interface in the same way routes are
 added for ethernet interfaces.
 
-3) Configure a bond interface with an "active-backup" slave configuration.
+3) Configure a bond-ext interface with an "active-backup" slave configuration.
+Also set max_bonds=0 parameter to the bonding kernel module. Preventing
+an empty bond0 from being created.
 ```
     - hosts: myhost
       roles:
         - role: network
+          network_extra_bonding_module_options: "max_bonds=0"
           network_bond_interfaces:
-            - device: bond0
+            - device: bond-ext
               address: 192.168.10.128
               netmask: 255.255.255.0
               bootproto: static
@@ -124,7 +128,9 @@ address obtained via DHCP.
               bond_slaves: [eth1, eth2]
 ```
 
-5) Configure a VLAN interface with the vlan tag 2 for an ethernet interface
+5) Configure a VLAN interface with the vlan tag 2 for an ethernet interface 
+and set nozeroconf to True (no 169.254.0.0/16 link local address).
+
 ```
     - hosts: myhost
       roles:
@@ -132,6 +138,7 @@ address obtained via DHCP.
           network_ether_interfaces:
             - device: eth1
               bootproto: static
+              nozeroconf: True
               address: 192.168.10.18
               netmask: 255.255.255.0
               gateway: 192.168.10.1
@@ -160,6 +167,7 @@ Describe your network configuration for each host in host vars:
     network_ether_interfaces:
            - device: eth1
              bootproto: static
+             nozeroconf: True
              address: 192.168.10.18
              netmask: 255.255.255.0
              gateway: 192.168.10.1

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/CSCfi/network_interface.svg?branch=master)](https://travis-ci.org/CSCfi/network_interface)
+
 network_interface
 =================
 

--- a/README.md
+++ b/README.md
@@ -45,45 +45,52 @@ Examples
 
 1) Configure eth1 and eth2 on a host with a static IP and a dhcp IP. Also
 define static routes and a gateway.
-
+```
     - hosts: myhost
       roles:
         - role: network
           network_ether_interfaces:
-           - device: eth1
-             bootproto: static
-             address: 192.168.10.18
-             netmask: 255.255.255.0
-             gateway: 192.168.10.1
-             route:
-              - network: 192.168.200.0
-                netmask: 255.255.255.0
-                gateway: 192.168.10.1
-              - network: 192.168.100.0
-                netmask: 255.255.255.0
-                gateway: 192.168.10.1
-           - device: eth2
-             bootproto: dhcp
+            - device: eth1
+              bootproto: static
+              address: 192.168.10.18
+              netmask: 255.255.255.0
+              gateway: 192.168.10.1
+              route:
+                - network: 192.168.200.0
+                  netmask: 255.255.255.0
+                  gateway: 192.168.10.1
+                - network: 192.168.100.0
+                  netmask: 255.255.255.0
+                  gateway: 192.168.10.1
+            - device: eth2
+              bootproto: dhcp
+```
 
 2) Configure a bridge interface with multiple NIcs added to the bridge.
-
+```
     - hosts: myhost
       roles:
         - role: network
           network_bridge_interfaces:
-           -  device: br1
+            - device: br1
               type: bridge
               address: 192.168.10.10
               netmask: 255.255.255.0
+              gateway: 192.168.10.1
               bootproto: static
               stp: "on"
-              ports: [eth1, eth2]
+          network_ether_interfaces:
+            - device: eth1
+              bootproto: none
+              onboot: yes
+              bridge: br1
+```
 
 Note: Routes can also be added for this interface in the same way routes are
 added for ethernet interfaces.
 
 3) Configure a bond interface with an "active-backup" slave configuration.
-
+```
     - hosts: myhost
       roles:
         - role: network
@@ -96,13 +103,14 @@ added for ethernet interfaces.
               bond_miimon: 100
               bond_slaves: [eth1, eth2]
               route:
-              - network: 192.168.222.0
-                netmask: 255.255.255.0
-                gateway: 192.168.10.1
+                - network: 192.168.222.0
+                  netmask: 255.255.255.0
+                  gateway: 192.168.10.1
+```
 
 4) Configure a bonded interface with "802.3ad" as the bonding mode and IP
 address obtained via DHCP.
-
+```
     - hosts: myhost
       roles:
         - role: network
@@ -112,23 +120,25 @@ address obtained via DHCP.
               bond_mode: 802.3ad
               bond_miimon: 100
               bond_slaves: [eth1, eth2]
+```
 
 5) Configure a VLAN interface with the vlan tag 2 for an ethernet interface
-
+```
     - hosts: myhost
       roles:
         - role: network
           network_ether_interfaces:
-           - device: eth1
-             bootproto: static
-             address: 192.168.10.18
-             netmask: 255.255.255.0
-             gateway: 192.168.10.1
+            - device: eth1
+              bootproto: static
+              address: 192.168.10.18
+              netmask: 255.255.255.0
+              gateway: 192.168.10.1
           network_vlan_interfaces:
-	   - device: eth1.2
-	     bootproto: static
-	     address: 192.168.20.18
-	     netmask: 255.255.255.0
+	          - device: eth1.2
+	            bootproto: static
+	            address: 192.168.20.18
+	            netmask: 255.255.255.0
+```
 
 6) All the above examples show how to configure a single host, The below
 example shows how to define your network configurations for all your machines.

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ define static routes and a gateway.
 ```
 
 2) Configure a bridge interface with multiple NIcs added to the bridge.
+Also set bridging_opts, an example in case you need multicasting.
 ```
     - hosts: myhost
       roles:
@@ -82,6 +83,7 @@ define static routes and a gateway.
               gateway: 192.168.10.1
               bootproto: static
               stp: "on"
+              bridging_opts: "multicast_snooping=1 multicast_querier=1"
           network_ether_interfaces:
             - device: eth1
               bootproto: none

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,3 +8,4 @@ network_check_packages: true
 network_allow_service_restart: true
 bond_modules_path: "/etc/modprobe.d"
 network_extra_bonding_module_options: ""
+network_ip_route_ephemeral: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,3 +11,4 @@ network_extra_bonding_module_options: ""
 network_ip_route_ephemeral: false
 network_bridge_ephemeral: false
 network_vlan_ephemeral: false
+network_service: "network"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,3 +3,4 @@ network_ether_interfaces: []
 network_bridge_interfaces: []
 network_bond_interfaces: []
 network_check_packages: true
+network_allow_service_restart: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,3 +2,4 @@
 network_ether_interfaces: []
 network_bridge_interfaces: []
 network_bond_interfaces: []
+network_check_packages: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,8 @@
 ---
+network_pkgs: []
 network_ether_interfaces: []
 network_bridge_interfaces: []
 network_bond_interfaces: []
+network_vlan_interfaces: []
 network_check_packages: true
 network_allow_service_restart: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,3 +6,5 @@ network_bond_interfaces: []
 network_vlan_interfaces: []
 network_check_packages: true
 network_allow_service_restart: true
+bond_modules_path: "/etc/modprobe.d"
+network_extra_bonding_module_options: ""

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,3 +9,5 @@ network_allow_service_restart: true
 bond_modules_path: "/etc/modprobe.d"
 network_extra_bonding_module_options: ""
 network_ip_route_ephemeral: false
+network_bridge_ephemeral: false
+network_vlan_ephemeral: false

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,0 +1,3 @@
+---
+- name: restart network
+  service: name=network state=restarted

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,3 +4,7 @@
     name: "{{ network_service }}"
     state: restarted
   when: network_allow_service_restart
+
+- name: toggle network
+  shell: "nmcli networking off && nmcli networking on"
+  when: network_allow_service_restart and network_service == "NetworkManager"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,4 +1,6 @@
 ---
 - name: restart network
-  service: name=network state=restarted
+  systemd:
+    name: "{{ network_service }}"
+    state: restarted
   when: network_allow_service_restart

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,3 +1,4 @@
 ---
 - name: restart network
   service: name=network state=restarted
+  when: network_allow_service_restart

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -5,6 +5,6 @@
     state: restarted
   when: network_allow_service_restart
 
-- name: toggle network
-  shell: "nmcli networking off && nmcli networking on"
+- name: toggle interface
+  include_tasks: handlers/toggle_interface.yml
   when: network_allow_service_restart and network_service == "NetworkManager"

--- a/handlers/toggle_interface.yml
+++ b/handlers/toggle_interface.yml
@@ -11,4 +11,9 @@
     - hostvars[inventory_hostname]['ansible_' + (item.1 | replace('-','_'))].ipv4.address is defined
     - hostvars[inventory_hostname]['ansible_' + (item.0.device | replace('-','_'))].ipv4.address == hostvars[inventory_hostname]['ansible_' + (item.1 | replace('-','_'))].ipv4.address
   loop: "{{ query('subelements', network_bond_interfaces, 'bond_slaves') }}"
+
+- name: reapply any interface with ipv4 addr to get all configurations activated
+  shell: "nmcli connection up 'System {{ item }}'"
+  when: ansible_facts[item].ipv4.address is defined and not 'lo' == item
+  loop: "{{ ansible_interfaces }}"
 ...

--- a/handlers/toggle_interface.yml
+++ b/handlers/toggle_interface.yml
@@ -11,6 +11,16 @@
     - hostvars[inventory_hostname]['ansible_' + (item.1 | replace('-','_'))].ipv4.address is defined
     - hostvars[inventory_hostname]['ansible_' + (item.0.device | replace('-','_'))].ipv4.address == hostvars[inventory_hostname]['ansible_' + (item.1 | replace('-','_'))].ipv4.address
   loop: "{{ query('subelements', network_bond_interfaces, 'bond_slaves') }}"
+  register: bond_toggled
+
+- name: toggle any interface still having same ip as its bridge
+  shell: "nmcli device disconnect {{ item.1 }} && sleep 10 && nmcli device connect {{ item.1 }}"
+  when:
+    - bond_toggled.results | map(attribute='skipped') | list is all
+    - hostvars[inventory_hostname]['ansible_' + (item.0.bridge | replace('-','_'))].ipv4.address is defined
+    - hostvars[inventory_hostname]['ansible_' + (item.1 | replace('-','_'))].ipv4.address is defined
+    - hostvars[inventory_hostname]['ansible_' + (item.0.bridge | replace('-','_'))].ipv4.address == hostvars[inventory_hostname]['ansible_' + (item.1 | replace('-','_'))].ipv4.address
+  loop: "{{ query('subelements', network_bond_interfaces, 'bond_slaves') }}"
 
 - name: reapply any interface with ipv4 addr to get all configurations activated
   shell: "nmcli connection up 'System {{ item }}'"

--- a/handlers/toggle_interface.yml
+++ b/handlers/toggle_interface.yml
@@ -24,6 +24,6 @@
 
 - name: reapply any interface with ipv4 addr to get all configurations activated
   shell: "nmcli connection up 'System {{ item }}'"
-  when: ansible_facts[item].ipv4.address is defined and not 'lo' == item
+  when: ansible_facts[item].ipv4.address is defined and not 'lo' == item and 'bond' not in item
   loop: "{{ ansible_interfaces }}"
 ...

--- a/handlers/toggle_interface.yml
+++ b/handlers/toggle_interface.yml
@@ -1,0 +1,14 @@
+---
+- name: Wait 10 secs for the effect of network restarting
+  wait_for:
+    timeout: 10
+- name: Update facts
+  setup:
+- name: toggle any interface still having same ip as its bond
+  shell: "nmcli device disconnect {{ item.1 }} && sleep 10 && nmcli device connect {{ item.1 }}"
+  when:
+    - hostvars[inventory_hostname]['ansible_' + (item.0.device | replace('-','_'))].ipv4.address is defined
+    - hostvars[inventory_hostname]['ansible_' + (item.1 | replace('-','_'))].ipv4.address is defined
+    - hostvars[inventory_hostname]['ansible_' + (item.0.device | replace('-','_'))].ipv4.address == hostvars[inventory_hostname]['ansible_' + (item.1 | replace('-','_'))].ipv4.address
+  loop: "{{ query('subelements', network_bond_interfaces, 'bond_slaves') }}"
+...

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: "Benno Joy"
   company: AnsibleWorks
   license: BSD
-  min_ansible_version: 1.4 
+  min_ansible_version: 1.4
   platforms:
    - name: EL
      versions:
@@ -24,4 +24,3 @@ galaxy_info:
     - networking
     - system
 dependencies: []
-  

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: "Benno Joy"
   company: AnsibleWorks
   license: BSD
-  min_ansible_version: 1.4
+  min_ansible_version: 2.4
   platforms:
    - name: EL
      versions:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -2,7 +2,7 @@
 galaxy_info:
   author: "Benno Joy"
   company: AnsibleWorks
-  license: "Simplified BSD License"
+  license: BSD
   min_ansible_version: 1.4 
   platforms:
    - name: EL

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -49,6 +49,16 @@
   template: src=route_{{ ansible_os_family }}.j2 dest={{ net_path }}/route-{{ item.device }}
   with_items: "{{ network_ether_interfaces }}"
   when: network_ether_interfaces is defined and item.route is defined and ansible_os_family == 'RedHat'
+  notify:
+   - restart network
+
+- name: Add ether routes manually to routing table if network_ip_route_ephemeral is True and if there is only one route on the interface
+  command: "ip route add {{ item.route[0].network }}/{{ item.route[0].netmask }} via {{ item.route[0].gateway }} dev {{ item.device }}"
+  with_items: "{{ network_ether_interfaces }}"
+  when: network_ether_interfaces is defined and item.route is defined and ansible_os_family == 'RedHat' and network_ip_route_ephemeral and item.route|length < 2
+  register: reg_network_iproute
+  failed_when: reg_network_iproute.rc|int != 0 and reg_network_iproute.rc|int != 2
+  changed_when: reg_network_iproute.rc|int == 0
 
 - name: Create the network configuration file for bond devices
   template: src=bond_{{ ansible_os_family }}.j2 dest={{ net_path }}/ifcfg-{{ item.device }}
@@ -72,6 +82,14 @@
   when: network_bond_interfaces is defined and item.route is defined and ansible_os_family == 'RedHat'
   notify:
    - restart network
+
+- name: Add bond routes manually to routing table if network_ip_route_ephemeral is True and if there is only one route on the interface
+  command: "ip route add {{ item.route[0].network }}/{{ item.route[0].netmask }} via {{ item.route[0].gateway }} dev {{ item.device }}"
+  with_items: "{{ network_bond_interfaces }}"
+  when: network_bond_interfaces is defined and item.route is defined and ansible_os_family == 'RedHat' and network_ip_route_ephemeral and item.route|length < 2
+  register: reg_network_iproute
+  failed_when: reg_network_iproute.rc|int != 0 and reg_network_iproute.rc|int != 2
+  changed_when: reg_network_iproute.rc|int == 0
 
 - name: Create the network configuration file for slave in the bond devices
   template: src=bond_slave_{{ ansible_os_family }}.j2 dest={{ net_path }}/ifcfg-{{ item.1 }}
@@ -99,6 +117,14 @@
   notify:
    - restart network
 
+- name: Add vlan routes manually to routing table if network_ip_route_ephemeral is True and if there is only one route on the interface
+  command: "ip route add {{ item.route[0].network }}/{{ item.route[0].netmask }} via {{ item.route[0].gateway }} dev {{ item.device }}"
+  with_items: "{{ network_vlan_interfaces }}"
+  when: network_bond_interfaces is defined and item.route is defined and ansible_os_family == 'RedHat' and network_ip_route_ephemeral and item.route|length < 2
+  register: reg_network_iproute
+  failed_when: reg_network_iproute.rc|int != 0 and reg_network_iproute.rc|int != 2
+  changed_when: reg_network_iproute.rc|int == 0
+
 - name: Create the network configuration file for bridge devices
   template: src=bridge_{{ ansible_os_family }}.j2 dest={{ net_path }}/ifcfg-{{ item.device }}
   with_items: "{{ network_bridge_interfaces }}"
@@ -113,3 +139,11 @@
   when: network_bridge_interfaces is defined and item.route is defined and ansible_os_family == 'RedHat'
   notify:
    - restart network
+
+- name: Add bridge routes manually to routing table if network_ip_route_ephemeral is True and if there is only one route on the interface
+  command: "ip route add {{ item.route[0].network }}/{{ item.route[0].netmask }} via {{ item.route[0].gateway }} dev {{ item.device }}"
+  with_items: "{{ network_bridge_interfaces }}"
+  when: network_bridge_interfaces is defined and item.route is defined and ansible_os_family == 'RedHat' and network_ip_route_ephemeral and item.route|length < 2
+  register: reg_network_iproute
+  failed_when: reg_network_iproute.rc|int != 0 and reg_network_iproute.rc|int != 2
+  changed_when: reg_network_iproute.rc|int == 0

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -35,7 +35,7 @@
    - restart network
 
 - name: Write configuration files for rhel route configuration
-  template: src=route_{{ ansible_os_family }}.j2 dest={{ net_path }}/route-{{ item.device }} 
+  template: src=route_{{ ansible_os_family }}.j2 dest={{ net_path }}/route-{{ item.device }}
   with_items: "{{ network_ether_interfaces }}"
   when: network_ether_interfaces is defined and item.route is defined and ansible_os_family == 'RedHat'
 
@@ -52,7 +52,7 @@
   when: bond_result|changed
 
 - name: Write configuration files for route configuration
-  template: src=route_{{ ansible_os_family }}.j2 dest={{ net_path }}/route-{{ item.device }} 
+  template: src=route_{{ ansible_os_family }}.j2 dest={{ net_path }}/route-{{ item.device }}
   with_items: "{{ network_bond_interfaces }}"
   when: network_bond_interfaces is defined and item.route is defined and ansible_os_family == 'RedHat'
   notify:
@@ -77,7 +77,7 @@
    - restart network
 
 - name: Write configuration files for rhel route configuration with vlan
-  template: src=route_{{ ansible_os_family }}.j2 dest={{ net_path }}/route-{{ item.device }} 
+  template: src=route_{{ ansible_os_family }}.j2 dest={{ net_path }}/route-{{ item.device }}
   with_items: "{{ network_vlan_interfaces }}"
   when: network_vlan_interfaces is defined and item.route is defined and ansible_os_family == 'RedHat'
   notify:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -60,6 +60,7 @@
   register: ether_result
   notify:
    - restart network
+   - toggle network
 
 - name: Write configuration files for rhel route configuration
   template: src=route_{{ ansible_os_family }}.j2 dest={{ net_path }}/route-{{ item.device }}
@@ -67,6 +68,7 @@
   when: network_ether_interfaces is defined and item.route is defined and ansible_os_family == 'RedHat'
   notify:
    - restart network
+   - toggle network
 
 - name: Add ether routes manually to routing table if network_ip_route_ephemeral is True and if there is only one route on the interface
   command: "ip route add {{ item.route[0].network }}/{{ item.route[0].netmask }} via {{ item.route[0].gateway }} dev {{ item.device }}"
@@ -83,6 +85,7 @@
   register: bond_result
   notify:
    - restart network
+   - toggle network
 
 - name: template in bonding.conf module settings
   template: src=bonding.conf.j2 dest={{ bond_modules_path}}/bonding.conf
@@ -98,6 +101,7 @@
   when: network_bond_interfaces is defined and item.route is defined and ansible_os_family == 'RedHat'
   notify:
    - restart network
+   - toggle network
 
 - name: Add bond routes manually to routing table if network_ip_route_ephemeral is True and if there is only one route on the interface
   command: "ip route add {{ item.route[0].network }}/{{ item.route[0].netmask }} via {{ item.route[0].gateway }} dev {{ item.device }}"
@@ -117,6 +121,7 @@
   register: bond_port_result
   notify:
    - restart network
+   - toggle network
 
 - name: Create the network configuration file for vlan devices
   template: src=ethernet_{{ ansible_os_family }}.j2 dest={{ net_path }}/ifcfg-{{ item.device }}
@@ -125,6 +130,7 @@
   register: vlan_result
   notify:
    - restart network
+   - toggle network
 
 - name: Add vlan interfaces manually if network_vlan_ephemeral is True
   command: "ip link add link {{ item.device.split('.')[0] }} name {{ item.device }} type vlan id {{ item.device.split('.')[1] }}"
@@ -166,6 +172,7 @@
   when: network_vlan_interfaces is defined and item.route is defined and ansible_os_family == 'RedHat'
   notify:
    - restart network
+   - toggle network
 
 - name: Add vlan routes manually to routing table if network_ip_route_ephemeral is True and if there is only one route on the interface
   command: "ip route add {{ item.route[0].network }}/{{ item.route[0].netmask }} via {{ item.route[0].gateway }} dev {{ item.device }}"
@@ -182,6 +189,7 @@
   register: bridge_result
   notify:
    - restart network
+   - toggle network
 
 - name: Add bridges manually if network_bridge_ephemeral is True
   command: "brctl addbr {{ item.device }}"
@@ -217,6 +225,7 @@
   when: network_bridge_interfaces is defined and item.route is defined and ansible_os_family == 'RedHat'
   notify:
    - restart network
+   - toggle network
 
 - name: Add bridge routes manually to routing table if network_ip_route_ephemeral is True and if there is only one route on the interface
   command: "ip route add {{ item.route[0].network }}/{{ item.route[0].netmask }} via {{ item.route[0].gateway }} dev {{ item.device }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -60,7 +60,7 @@
   register: ether_result
   notify:
    - restart network
-   - toggle network
+   - toggle interface
 
 - name: Write configuration files for rhel route configuration
   template: src=route_{{ ansible_os_family }}.j2 dest={{ net_path }}/route-{{ item.device }}
@@ -68,7 +68,7 @@
   when: network_ether_interfaces is defined and item.route is defined and ansible_os_family == 'RedHat'
   notify:
    - restart network
-   - toggle network
+   - toggle interface
 
 - name: Add ether routes manually to routing table if network_ip_route_ephemeral is True and if there is only one route on the interface
   command: "ip route add {{ item.route[0].network }}/{{ item.route[0].netmask }} via {{ item.route[0].gateway }} dev {{ item.device }}"
@@ -85,7 +85,7 @@
   register: bond_result
   notify:
    - restart network
-   - toggle network
+   - toggle interface
 
 - name: template in bonding.conf module settings
   template: src=bonding.conf.j2 dest={{ bond_modules_path}}/bonding.conf
@@ -101,7 +101,7 @@
   when: network_bond_interfaces is defined and item.route is defined and ansible_os_family == 'RedHat'
   notify:
    - restart network
-   - toggle network
+   - toggle interface
 
 - name: Add bond routes manually to routing table if network_ip_route_ephemeral is True and if there is only one route on the interface
   command: "ip route add {{ item.route[0].network }}/{{ item.route[0].netmask }} via {{ item.route[0].gateway }} dev {{ item.device }}"
@@ -121,7 +121,7 @@
   register: bond_port_result
   notify:
    - restart network
-   - toggle network
+   - toggle interface
 
 - name: Create the network configuration file for vlan devices
   template: src=ethernet_{{ ansible_os_family }}.j2 dest={{ net_path }}/ifcfg-{{ item.device }}
@@ -130,7 +130,7 @@
   register: vlan_result
   notify:
    - restart network
-   - toggle network
+   - toggle interface
 
 - name: Add vlan interfaces manually if network_vlan_ephemeral is True
   command: "ip link add link {{ item.device.split('.')[0] }} name {{ item.device }} type vlan id {{ item.device.split('.')[1] }}"
@@ -172,7 +172,7 @@
   when: network_vlan_interfaces is defined and item.route is defined and ansible_os_family == 'RedHat'
   notify:
    - restart network
-   - toggle network
+   - toggle interface
 
 - name: Add vlan routes manually to routing table if network_ip_route_ephemeral is True and if there is only one route on the interface
   command: "ip route add {{ item.route[0].network }}/{{ item.route[0].netmask }} via {{ item.route[0].gateway }} dev {{ item.device }}"
@@ -189,7 +189,7 @@
   register: bridge_result
   notify:
    - restart network
-   - toggle network
+   - toggle interface
 
 - name: Add bridges manually if network_bridge_ephemeral is True
   command: "brctl addbr {{ item.device }}"
@@ -225,7 +225,7 @@
   when: network_bridge_interfaces is defined and item.route is defined and ansible_os_family == 'RedHat'
   notify:
    - restart network
-   - toggle network
+   - toggle interface
 
 - name: Add bridge routes manually to routing table if network_ip_route_ephemeral is True and if there is only one route on the interface
   command: "ip route add {{ item.route[0].network }}/{{ item.route[0].netmask }} via {{ item.route[0].gateway }} dev {{ item.device }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Add the OS specific varibles
   include_vars: "{{ ansible_os_family }}.yml"
 
@@ -13,7 +12,6 @@
   with_items: network_pkgs
   environment: env
   when: ansible_os_family == 'Debian'
-
 
 - name: Make sure the include line is there in interfaces file
   lineinfile: >
@@ -41,10 +39,6 @@
   with_items: network_ether_interfaces
   when: network_ether_interfaces is defined and item.route is defined and ansible_os_family == 'RedHat'
 
-#- shell: ifdown {{ item.item.device }}; ifup {{ item.item.device }}
-#  with_items: ether_result.results
-#  when: ether_result is defined and item.changed
-
 - name: Create the network configuration file for bond devices
   template: src=bond_{{ ansible_os_family }}.j2 dest={{ net_path }}/ifcfg-{{ item.device }}
   with_items: network_bond_interfaces
@@ -64,10 +58,6 @@
   notify:
    - restart network
 
-#- shell: ifdown {{ item.item.device }}; ifup {{ item.item.device }}
-#  with_items: bond_result.results
-#  when: bond_result is defined and item.changed
-
 - name: Create the network configuration file for slave in the bond devices
   template: src=bond_slave_{{ ansible_os_family }}.j2 dest={{ net_path }}/ifcfg-{{ item.1 }}
   with_subelements:
@@ -77,14 +67,6 @@
   register: bond_port_result
   notify:
    - restart network
-
-#- shell: ifdown {{ item.item.1 }}; ifup {{ item.item.1 }}
-#  with_items: bond_port_result.results
-#  when: bond_port_result is defined and item.changed
-
-#- shell: ifdown {{ item.item.device }}; ifup {{ item.item.device }}
-#  with_items: bond_result.results
-#  when: bond_result is defined and item.changed and ansible_os_family == 'RedHat'
 
 - name: Create the network configuration file for vlan devices
   template: src=ethernet_{{ ansible_os_family }}.j2 dest={{ net_path }}/ifcfg-{{ item.device }}
@@ -101,10 +83,6 @@
   notify:
    - restart network
 
-#- shell: ifdown {{ item.item.device }}; ifup {{ item.item.device }}
-#  with_items: vlan_result.results
-#  when: vlan_result is defined and item.changed
-
 - name: Create the network configuration file for bridge devices
   template: src=bridge_{{ ansible_os_family }}.j2 dest={{ net_path }}/ifcfg-{{ item.device }}
   with_items: network_bridge_interfaces
@@ -119,10 +97,6 @@
   when: network_bridge_interfaces is defined and item.route is defined and ansible_os_family == 'RedHat'
   notify:
    - restart network
-
-#- shell: ifdown {{ item.item.device }}; ifup {{ item.item.device }}
-#  with_items: bridge_result.results
-#  when: bridge_result is defined and item.changed
 
 - name: Create the network configuration file for port on the bridge devices
   lineinfile: dest={{ net_path }}/ifcfg-{{ item.1 }} regexp='^BRIDGE=' line=BRIDGE={{ item.0.device }}

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,7 +6,7 @@
 - name: Install the required  packages in Redhat derivatives
   yum: name={{ item }} state=installed
   with_items: network_pkgs
-  when: ansible_os_family == 'RedHat'
+  when: ansible_os_family == 'RedHat' and network_check_packages
 
 - name: Install the required packages in Debian derivatives
   apt: name={{ item }} state=installed update_cache=yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -61,7 +61,7 @@
 - name: Create the network configuration file for slave in the bond devices
   template: src=bond_slave_{{ ansible_os_family }}.j2 dest={{ net_path }}/ifcfg-{{ item.1 }}
   with_subelements:
-   - network_bond_interfaces
+   - "{{network_bond_interfaces}}"
    - bond_slaves
   when: network_bond_interfaces is defined
   register: bond_port_result
@@ -101,7 +101,7 @@
 - name: Create the network configuration file for port on the bridge devices
   lineinfile: dest={{ net_path }}/ifcfg-{{ item.1 }} regexp='^BRIDGE=' line=BRIDGE={{ item.0.device }}
   with_subelements:
-    - network_bridge_interfaces
+    - "{{network_bridge_interfaces}}"
     - ports
   when: network_bridge_interfaces is defined
   register: bridge_port_result

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,13 +10,17 @@
   include_vars: "{{ ansible_os_family }}.yml"
 
 - name: Install the required  packages in Redhat derivatives
-  yum: name={{ item }} state=installed
-  with_items: "{{ network_pkgs }}"
+  yum:
+    name: "{{ network_pkgs }}"
+  vars:
+     packages:  "{{ network_pkgs }}"
   when: ansible_os_family == 'RedHat' and network_check_packages
 
 - name: Install the required packages in Debian derivatives
-  apt: name={{ item }} state=installed update_cache=yes
-  with_items: "{{ network_pkgs }}"
+  apt:
+    name: "{{ network_pkgs }}"
+  vars:
+     packages:  "{{ network_pkgs }}"
   environment: env
   when: ansible_os_family == 'Debian'
 
@@ -74,6 +78,7 @@
   with_subelements:
    - "{{network_bond_interfaces}}"
    - bond_slaves
+
   when: network_bond_interfaces is defined
   register: bond_port_result
   notify:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,7 +28,7 @@
 
 - name: Create the network configuration file for ethernet devices
   template: src=ethernet_{{ ansible_os_family }}.j2 dest={{ net_path }}/ifcfg-{{ item.device }}
-  with_items: "{{ network_ether_interfaces }}”
+  with_items: "{{ network_ether_interfaces }}"
   when: network_ether_interfaces is defined
   register: ether_result
   notify:
@@ -36,7 +36,7 @@
 
 - name: Write configuration files for rhel route configuration
   template: src=route_{{ ansible_os_family }}.j2 dest={{ net_path }}/route-{{ item.device }} 
-  with_items: "{{ network_ether_interfaces }}”
+  with_items: "{{ network_ether_interfaces }}"
   when: network_ether_interfaces is defined and item.route is defined and ansible_os_family == 'RedHat'
 
 - name: Create the network configuration file for bond devices
@@ -93,7 +93,7 @@
 
 - name: Write configuration files for rhel route configuration
   template: src=route_{{ ansible_os_family }}.j2 dest={{ net_path }}/route-{{ item.device }}
-  with_items: "{{ network_bridge_interfaces }}”
+  with_items: "{{ network_bridge_interfaces }}"
   when: network_bridge_interfaces is defined and item.route is defined and ansible_os_family == 'RedHat'
   notify:
    - restart network

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -56,7 +56,7 @@
 
 - name: Make sure the bonding module is loaded
   modprobe: name=bonding state=present
-  when: bond_result|changed
+  when: bond_result is changed
 
 - name: Write configuration files for route configuration
   template: src=route_{{ ansible_os_family }}.j2 dest={{ net_path }}/route-{{ item.device }}

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,11 @@
 ---
+- name: Check if the bridge ports are still defined using the old way
+  fail:
+    msg: "Ports shouldn't be defined this way."
+  when: item.ports is defined
+  with_items:
+    - "{{ network_bridge_interfaces }}"
+
 - name: Add the OS specific varibles
   include_vars: "{{ ansible_os_family }}.yml"
 
@@ -95,15 +102,5 @@
   template: src=route_{{ ansible_os_family }}.j2 dest={{ net_path }}/route-{{ item.device }}
   with_items: "{{ network_bridge_interfaces }}"
   when: network_bridge_interfaces is defined and item.route is defined and ansible_os_family == 'RedHat'
-  notify:
-   - restart network
-
-- name: Create the network configuration file for port on the bridge devices
-  lineinfile: dest={{ net_path }}/ifcfg-{{ item.1 }} regexp='^BRIDGE=' line=BRIDGE={{ item.0.device }}
-  with_subelements:
-    - "{{network_bridge_interfaces}}"
-    - ports
-  when: network_bridge_interfaces is defined
-  register: bridge_port_result
   notify:
    - restart network

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,12 +4,12 @@
 
 - name: Install the required  packages in Redhat derivatives
   yum: name={{ item }} state=installed
-  with_items: network_pkgs
+  with_items: "{{ network_pkgs }}"
   when: ansible_os_family == 'RedHat' and network_check_packages
 
 - name: Install the required packages in Debian derivatives
   apt: name={{ item }} state=installed update_cache=yes
-  with_items: network_pkgs
+  with_items: "{{ network_pkgs }}"
   environment: env
   when: ansible_os_family == 'Debian'
 
@@ -28,7 +28,7 @@
 
 - name: Create the network configuration file for ethernet devices
   template: src=ethernet_{{ ansible_os_family }}.j2 dest={{ net_path }}/ifcfg-{{ item.device }}
-  with_items: network_ether_interfaces
+  with_items: "{{ network_ether_interfaces }}”
   when: network_ether_interfaces is defined
   register: ether_result
   notify:
@@ -36,12 +36,12 @@
 
 - name: Write configuration files for rhel route configuration
   template: src=route_{{ ansible_os_family }}.j2 dest={{ net_path }}/route-{{ item.device }} 
-  with_items: network_ether_interfaces
+  with_items: "{{ network_ether_interfaces }}”
   when: network_ether_interfaces is defined and item.route is defined and ansible_os_family == 'RedHat'
 
 - name: Create the network configuration file for bond devices
   template: src=bond_{{ ansible_os_family }}.j2 dest={{ net_path }}/ifcfg-{{ item.device }}
-  with_items: network_bond_interfaces
+  with_items: "{{ network_bond_interfaces }}"
   when: network_bond_interfaces is defined
   register: bond_result
   notify:
@@ -53,7 +53,7 @@
 
 - name: Write configuration files for route configuration
   template: src=route_{{ ansible_os_family }}.j2 dest={{ net_path }}/route-{{ item.device }} 
-  with_items: network_bond_interfaces
+  with_items: "{{ network_bond_interfaces }}"
   when: network_bond_interfaces is defined and item.route is defined and ansible_os_family == 'RedHat'
   notify:
    - restart network
@@ -70,7 +70,7 @@
 
 - name: Create the network configuration file for vlan devices
   template: src=ethernet_{{ ansible_os_family }}.j2 dest={{ net_path }}/ifcfg-{{ item.device }}
-  with_items: network_vlan_interfaces
+  with_items: "{{ network_vlan_interfaces }}"
   when: network_vlan_interfaces is defined
   register: vlan_result
   notify:
@@ -78,14 +78,14 @@
 
 - name: Write configuration files for rhel route configuration with vlan
   template: src=route_{{ ansible_os_family }}.j2 dest={{ net_path }}/route-{{ item.device }} 
-  with_items: network_vlan_interfaces
+  with_items: "{{ network_vlan_interfaces }}"
   when: network_vlan_interfaces is defined and item.route is defined and ansible_os_family == 'RedHat'
   notify:
    - restart network
 
 - name: Create the network configuration file for bridge devices
   template: src=bridge_{{ ansible_os_family }}.j2 dest={{ net_path }}/ifcfg-{{ item.device }}
-  with_items: network_bridge_interfaces
+  with_items: "{{ network_bridge_interfaces }}"
   when: network_bridge_interfaces is defined
   register: bridge_result
   notify:
@@ -93,7 +93,7 @@
 
 - name: Write configuration files for rhel route configuration
   template: src=route_{{ ansible_os_family }}.j2 dest={{ net_path }}/route-{{ item.device }}
-  with_items: network_bridge_interfaces
+  with_items: "{{ network_bridge_interfaces }}”
   when: network_bridge_interfaces is defined and item.route is defined and ansible_os_family == 'RedHat'
   notify:
    - restart network

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -54,6 +54,10 @@
   notify:
    - restart network
 
+- name: template in bonding.conf module settings
+  template: src=bonding.conf.j2 dest={{ bond_modules_path}}/bonding.conf
+  when: network_bond_interfaces is defined and network_extra_bonding_module_options != ""
+
 - name: Make sure the bonding module is loaded
   modprobe: name=bonding state=present
   when: bond_result is changed

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -33,48 +33,25 @@
   with_items: network_ether_interfaces
   when: network_ether_interfaces is defined
   register: ether_result
+  notify:
+   - restart network
 
 - name: Write configuration files for rhel route configuration
   template: src=route_{{ ansible_os_family }}.j2 dest={{ net_path }}/route-{{ item.device }} 
   with_items: network_ether_interfaces
   when: network_ether_interfaces is defined and item.route is defined and ansible_os_family == 'RedHat'
 
-- shell: ifdown {{ item.item.device }}; ifup {{ item.item.device }}
-  with_items: ether_result.results
-  when: ether_result is defined and item.changed
-
-- name: Create the network configuration file for bridge devices
-  template: src=bridge_{{ ansible_os_family }}.j2 dest={{ net_path }}/ifcfg-{{ item.device }}
-  with_items: network_bridge_interfaces
-  when: network_bridge_interfaces is defined 
-  register: bridge_result
-
-- name: Write configuration files for rhel route configuration
-  template: src=route_{{ ansible_os_family }}.j2 dest={{ net_path }}/route-{{ item.device }} 
-  with_items: network_bridge_interfaces
-  when: network_bridge_interfaces is defined and item.route is defined and ansible_os_family == 'RedHat'
-
-- shell: ifdown {{ item.item.device }}; ifup {{ item.item.device }}
-  with_items: bridge_result.results
-  when: bridge_result is defined and item.changed
- 
-- name: Create the network configuration file for port on the bridge devices
-  template: src=bridge_port_{{ ansible_os_family }}.j2 dest={{ net_path }}/ifcfg-{{ item.1 }}
-  with_subelements: 
-   - network_bridge_interfaces
-   - ports
-  when: network_bridge_interfaces is defined 
-  register: bridge_port_result
-
-- shell: ifdown {{ item.item.1 }}; ifup {{ item.item.1 }}
-  with_items: bridge_port_result.results
-  when: bridge_port_result is defined and item.changed
+#- shell: ifdown {{ item.item.device }}; ifup {{ item.item.device }}
+#  with_items: ether_result.results
+#  when: ether_result is defined and item.changed
 
 - name: Create the network configuration file for bond devices
   template: src=bond_{{ ansible_os_family }}.j2 dest={{ net_path }}/ifcfg-{{ item.device }}
   with_items: network_bond_interfaces
   when: network_bond_interfaces is defined
   register: bond_result
+  notify:
+   - restart network
 
 - name: Make sure the bonding module is loaded
   modprobe: name=bonding state=present
@@ -84,23 +61,75 @@
   template: src=route_{{ ansible_os_family }}.j2 dest={{ net_path }}/route-{{ item.device }} 
   with_items: network_bond_interfaces
   when: network_bond_interfaces is defined and item.route is defined and ansible_os_family == 'RedHat'
+  notify:
+   - restart network
 
-- shell: ifdown {{ item.item.device }}; ifup {{ item.item.device }}
-  with_items: bond_result.results
-  when: bond_result is defined and item.changed
+#- shell: ifdown {{ item.item.device }}; ifup {{ item.item.device }}
+#  with_items: bond_result.results
+#  when: bond_result is defined and item.changed
 
 - name: Create the network configuration file for slave in the bond devices
   template: src=bond_slave_{{ ansible_os_family }}.j2 dest={{ net_path }}/ifcfg-{{ item.1 }}
-  with_subelements: 
+  with_subelements:
    - network_bond_interfaces
    - bond_slaves
   when: network_bond_interfaces is defined
   register: bond_port_result
+  notify:
+   - restart network
 
-- shell: ifdown {{ item.item.1 }}; ifup {{ item.item.1 }}
-  with_items: bond_port_result.results
-  when: bond_port_result is defined and item.changed
+#- shell: ifdown {{ item.item.1 }}; ifup {{ item.item.1 }}
+#  with_items: bond_port_result.results
+#  when: bond_port_result is defined and item.changed
 
-- shell: ifdown {{ item.item.device }}; ifup {{ item.item.device }}
-  with_items: bond_result.results
-  when: bond_result is defined and item.changed and ansible_os_family == 'RedHat'
+#- shell: ifdown {{ item.item.device }}; ifup {{ item.item.device }}
+#  with_items: bond_result.results
+#  when: bond_result is defined and item.changed and ansible_os_family == 'RedHat'
+
+- name: Create the network configuration file for vlan devices
+  template: src=ethernet_{{ ansible_os_family }}.j2 dest={{ net_path }}/ifcfg-{{ item.device }}
+  with_items: network_vlan_interfaces
+  when: network_vlan_interfaces is defined
+  register: vlan_result
+  notify:
+   - restart network
+
+- name: Write configuration files for rhel route configuration with vlan
+  template: src=route_{{ ansible_os_family }}.j2 dest={{ net_path }}/route-{{ item.device }} 
+  with_items: network_vlan_interfaces
+  when: network_vlan_interfaces is defined and item.route is defined and ansible_os_family == 'RedHat'
+  notify:
+   - restart network
+
+#- shell: ifdown {{ item.item.device }}; ifup {{ item.item.device }}
+#  with_items: vlan_result.results
+#  when: vlan_result is defined and item.changed
+
+- name: Create the network configuration file for bridge devices
+  template: src=bridge_{{ ansible_os_family }}.j2 dest={{ net_path }}/ifcfg-{{ item.device }}
+  with_items: network_bridge_interfaces
+  when: network_bridge_interfaces is defined
+  register: bridge_result
+  notify:
+   - restart network
+
+- name: Write configuration files for rhel route configuration
+  template: src=route_{{ ansible_os_family }}.j2 dest={{ net_path }}/route-{{ item.device }}
+  with_items: network_bridge_interfaces
+  when: network_bridge_interfaces is defined and item.route is defined and ansible_os_family == 'RedHat'
+  notify:
+   - restart network
+
+#- shell: ifdown {{ item.item.device }}; ifup {{ item.item.device }}
+#  with_items: bridge_result.results
+#  when: bridge_result is defined and item.changed
+
+- name: Create the network configuration file for port on the bridge devices
+  lineinfile: dest={{ net_path }}/ifcfg-{{ item.1 }} regexp='^BRIDGE=' line=BRIDGE={{ item.0.device }}
+  with_subelements:
+    - network_bridge_interfaces
+    - ports
+  when: network_bridge_interfaces is defined
+  register: bridge_port_result
+  notify:
+   - restart network

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,20 +9,21 @@
 - name: Add the OS specific varibles
   include_vars: "{{ ansible_os_family }}.yml"
 
-- name: Check if we are in CentOS 8
+- name: Check if we are in RHEL8 or RHEL9 variant
   set_fact:
-    os_centos8: "{{ ansible_facts['distribution'] == 'CentOS' and ansible_facts['distribution_major_version'] == '8' }}"
+    os_rhel8_9based: "{{ ansible_os_family == 'RedHat' and ansible_facts['distribution_major_version'] >= '8' }}"
 
-- name: Install prerequisites for CentOS 8
+- name: Install prerequisites for RHEL8/RHEL9 variants
   yum:
-    name: epel-release,network-scripts
+    name: epel-release
     state: latest
-  when: os_centos8
+  when: os_rhel8_9based
 
-- name: Adjust vars in case of CentOS 8
+- name: Adjust vars in case of RHEL8/RHEL9 variant
   set_fact:
-    network_pkgs: "{{ network_pkgs_centos8 }}"
-  when: os_centos8
+    network_pkgs: "{{ network_pkgs_rhel8_9based }}"
+    network_service: "NetworkManager"
+  when: os_rhel8_9based
 
 - name: Install the required  packages in Redhat derivatives
   yum:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,6 +9,21 @@
 - name: Add the OS specific varibles
   include_vars: "{{ ansible_os_family }}.yml"
 
+- name: Check if we are in CentOS 8
+  set_fact:
+    os_centos8: "{{ ansible_facts['distribution'] == 'CentOS' and ansible_facts['distribution_major_version'] == '8' }}"
+
+- name: Install prerequisites for CentOS 8
+  yum:
+    name: epel-release,network-scripts
+    state: latest
+  when: os_centos8
+
+- name: Adjust vars in case of CentOS 8
+  set_fact:
+    network_pkgs: "{{ network_pkgs_centos8 }}"
+  when: os_centos8
+
 - name: Install the required  packages in Redhat derivatives
   yum:
     name: "{{ network_pkgs }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -110,6 +110,24 @@
   notify:
    - restart network
 
+- name: Add vlan interfaces manually if network_vlan_ephemeral is True
+  command: "ip link add link {{ item.device.split('.')[0] }} name {{ item.device }} type vlan id {{ item.device.split('.')[1] }}"
+  args:
+    creates: "/sys/devices/virtual/net/{{ item.device }}"
+  with_items: "{{ network_vlan_interfaces }}"
+  when: network_vlan_interfaces is defined and ansible_os_family == 'RedHat' and network_vlan_ephemeral
+  register: reg_network_vlan
+  failed_when: reg_network_vlan.rc|int != 0 and reg_network_vlan.rc|int != 2
+  changed_when: reg_network_vlan.rc|int == 0
+
+- name: Set MTU manually on vlan interfaces if network_vlan_ephemeral is True and the interface parameters include mtu
+  command: "ip link set mtu {{ item.mtu }} {{ item.device }}"
+  with_items: "{{ network_vlan_interfaces }}"
+  when: network_vlan_interfaces is defined and ansible_os_family == 'RedHat' and network_vlan_ephemeral and item.mtu is defined
+  register: reg_network_vlan
+  failed_when: reg_network_vlan.rc|int != 0 and reg_network_vlan.rc|int != 2
+  changed_when: reg_network_vlan.rc|int == 0
+
 - name: Write configuration files for rhel route configuration with vlan
   template: src=route_{{ ansible_os_family }}.j2 dest={{ net_path }}/route-{{ item.device }}
   with_items: "{{ network_vlan_interfaces }}"
@@ -132,6 +150,26 @@
   register: bridge_result
   notify:
    - restart network
+
+- name: Add bridges manually if network_bridge_ephemeral is True
+  command: "brctl addbr {{ item.device }}"
+  args:
+    creates: "/sys/devices/virtual/net/{{ item.device }}"
+  with_items: "{{ network_bridge_interfaces }}"
+  when: network_bridge_interfaces is defined and ansible_os_family == 'RedHat' and network_bridge_ephemeral
+  register: reg_network_bridge
+  failed_when: reg_network_bridge.rc|int != 0 and reg_network_bridge.rc|int != 2
+  changed_when: reg_network_bridge.rc|int == 0
+
+- name: Plug VLAN interfaces to bridges manually if network_bridge_ephemeral and network_vlan_ephemeral are True
+  command: "brctl addif {{ item.bridge }} {{ item.device }}"
+  args:
+    creates: "/sys/devices/virtual/net/{{ item.bridge }}/lower_{{ item.device }}"
+  with_items: "{{ network_vlan_interfaces }}"
+  when: network_bridge_interfaces is defined and ansible_os_family == 'RedHat' and network_bridge_ephemeral and network_vlan_ephemeral
+  register: reg_network_bridge_vlan
+  failed_when: reg_network_bridge_vlan.rc|int != 0 and reg_network_bridge_vlan.rc|int != 2
+  changed_when: reg_network_bridge_vlan.rc|int == 0
 
 - name: Write configuration files for rhel route configuration
   template: src=route_{{ ansible_os_family }}.j2 dest={{ net_path }}/route-{{ item.device }}

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -177,6 +177,14 @@
   failed_when: reg_network_bridge.rc|int != 0 and reg_network_bridge.rc|int != 2
   changed_when: reg_network_bridge.rc|int == 0
 
+- name: Ensure bridge interface is up if network_bridge_ephemeral is True
+  command: "ip link set up {{ item.device }}"
+  with_items: "{{ network_bridge_interfaces }}"
+  when: network_bridge_interfaces is defined and ansible_os_family == 'RedHat' and network_bridge_ephemeral
+  register: reg_network_bridge
+  failed_when: reg_network_bridge.rc|int != 0 and reg_network_bridge.rc|int != 2
+  changed_when: reg_network_bridge.rc|int == 0
+
 - name: Plug VLAN interfaces to bridges manually if network_bridge_ephemeral and network_vlan_ephemeral are True
   command: "brctl addif {{ item.bridge }} {{ item.device }}"
   args:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -209,3 +209,6 @@
   register: reg_network_iproute
   failed_when: reg_network_iproute.rc|int != 0 and reg_network_iproute.rc|int != 2
   changed_when: reg_network_iproute.rc|int == 0
+
+- name: Make sure that are handlers are done before ending the role
+  meta: flush_handlers

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -128,6 +128,22 @@
   failed_when: reg_network_vlan.rc|int != 0 and reg_network_vlan.rc|int != 2
   changed_when: reg_network_vlan.rc|int == 0
 
+- name: Add vlan interface IP address manually if network_vlan_ephemeral is True and the interface parameters include address
+  command: "ip addr add {{ item.address }}/{{ item.netmask }} dev {{ item.device }}"
+  with_items: "{{ network_vlan_interfaces }}"
+  when: network_vlan_interfaces is defined and ansible_os_family == 'RedHat' and network_vlan_ephemeral and item.address is defined
+  register: reg_network_vlan
+  failed_when: reg_network_vlan.rc|int != 0 and reg_network_vlan.rc|int != 2
+  changed_when: reg_network_vlan.rc|int == 0
+
+- name: Ensure vlan interface is up if network_vlan_ephemeral is True
+  command: "ip link set up {{ item.device }}"
+  with_items: "{{ network_vlan_interfaces }}"
+  when: network_vlan_interfaces is defined and ansible_os_family == 'RedHat' and network_vlan_ephemeral
+  register: reg_network_vlan
+  failed_when: reg_network_vlan.rc|int != 0 and reg_network_vlan.rc|int != 2
+  changed_when: reg_network_vlan.rc|int == 0
+
 - name: Write configuration files for rhel route configuration with vlan
   template: src=route_{{ ansible_os_family }}.j2 dest={{ net_path }}/route-{{ item.device }}
   with_items: "{{ network_vlan_interfaces }}"

--- a/templates/bond_Debian.j2
+++ b/templates/bond_Debian.j2
@@ -10,28 +10,28 @@ netmask {{ item.netmask }}
 {% if item.gateway is defined %}
 gateway {{ item.gateway }}
 {% endif %}
-{% if item.bond_mode is defined %}        
+{% if item.bond_mode is defined %}
 bond-mode {{ item.bond_mode }}
 {% endif %}
 bond-miimon {{ item.bond_miimon|default(100) }}
-{% if item.bond_slaves is defined and item.bond_mode == 'active-backup' %}        
+{% if item.bond_slaves is defined and item.bond_mode == 'active-backup' %}
 bond-slaves none
 {% endif %}
-{% if item.bond_slaves is defined and item.bond_mode == '802.3ad' %}        
+{% if item.bond_slaves is defined and item.bond_mode == '802.3ad' %}
 bond-slaves {{ item.bond_slaves|join(' ') }}
 {% endif %}
 {% endif %}
 
 {% if item.bootproto == 'dhcp' %}
 iface {{ item.device }}  inet dhcp
-{% if item.bond_mode is defined %}        
+{% if item.bond_mode is defined %}
 bond-mode {{ item.bond_mode }}
 {% endif %}
 bond-miimon {{ item.bond_miimon|default(100) }}
-{% if item.bond_slaves is defined and item.bond_mode == 'active-backup' %}        
+{% if item.bond_slaves is defined and item.bond_mode == 'active-backup' %}
 bond-slaves none
 {% endif %}
-{% if item.bond_slaves is defined and item.bond_mode == '802.3ad' %}        
+{% if item.bond_slaves is defined and item.bond_mode == '802.3ad' %}
 bond-slaves {{ item.bond_slaves|join(' ') }}
 {% endif %}
 {% endif %}
@@ -41,4 +41,3 @@ bond-slaves {{ item.bond_slaves|join(' ') }}
 up route add -net {{ i.network }}  netmask {{ i.netmask }} gw {{ i.gateway }} dev {{ item.device }}
 {% endfor %}
 {% endif %}
-

--- a/templates/bond_RedHat.j2
+++ b/templates/bond_RedHat.j2
@@ -1,4 +1,3 @@
-
 {% if item.bootproto != 'dhcp' %}
 DEVICE={{ item.device }}
 USERCTL=no

--- a/templates/bond_RedHat.j2
+++ b/templates/bond_RedHat.j2
@@ -1,5 +1,5 @@
 
-{% if item.bootproto == 'static' %}
+{% if item.bootproto != 'dhcp' %}
 DEVICE={{ item.device }}
 USERCTL=no
 BOOTPROTO=none
@@ -15,12 +15,12 @@ NETMASK={{ item.netmask }}
 {% if item.gateway is defined %}
 GATEWAY={{ item.gateway }}
 {% endif %}
-BONDING_OPTS="mode={{ item.bond_mode }} miimon={{ item.bond_miimon|default(100) }} "
+BONDING_OPTS="mode={{ item.bond_mode }} miimon={{ item.bond_miimon|default(100) }} {{ item.bond_extra_opts|default('') }} "
 {% endif %}
 
 {% if item.bootproto == 'dhcp' %}
 DEVICE={{ item.device }}
-BONDING_OPTS="mode={{ item.bond_mode }} miimon={{ item.bond_miimon|default(100) }} "
+BONDING_OPTS="mode={{ item.bond_mode }} miimon={{ item.bond_miimon|default(100) }} {{ item.bond_extra_opts|default('') }} "
 USERCTL=no
 ONBOOT={{ item.onboot|default("yes") }}
 BOOTPROTO=dhcp
@@ -36,4 +36,12 @@ DEFROUTE={{ item.defroute }}
 
 {% if item.mtu is defined %}
 MTU={{ item.mtu }}
+{% endif %}
+
+{% if item.bonding_master is defined %}
+BONDING_MASTER={{ item.bonding_master }}
+{% endif %}
+
+{% if item.bridge is defined %}
+BRIDGE={{ item.bridge }}
 {% endif %}

--- a/templates/bond_RedHat.j2
+++ b/templates/bond_RedHat.j2
@@ -50,3 +50,9 @@ BRIDGE={{ item.bridge }}
 {%- if item.zone is defined -%}
 ZONE={{ item.zone }}
 {% endif %}
+{%- if item.dns1 is defined -%}
+DNS1={{ item.dns1 }}
+{% endif %}
+{%- if item.dns2 is defined -%}
+DNS2={{ item.dns2 }}
+{% endif %}

--- a/templates/bond_RedHat.j2
+++ b/templates/bond_RedHat.j2
@@ -33,3 +33,7 @@ NM_CONTROLLED={{ item.nm_controlled }}
 {% if item.defroute is defined %}
 DEFROUTE={{ item.defroute }}
 {% endif %}
+
+{% if item.mtu is defined %}
+MTU={{ item.mtu }}
+{% endif %}

--- a/templates/bond_RedHat.j2
+++ b/templates/bond_RedHat.j2
@@ -36,8 +36,8 @@ DEFROUTE={{ item.defroute }}
 {% if item.mtu is defined %}
 MTU={{ item.mtu }}
 {% endif %}
-{%- if item.zeroconf is defined -%}
-NOZEROCONF={{ item.zeroconf }}
+{%- if item.nozeroconf is defined -%}
+NOZEROCONF={{ item.nozeroconf }}
 {% endif %}
 
 {% if item.bonding_master is defined %}

--- a/templates/bond_RedHat.j2
+++ b/templates/bond_RedHat.j2
@@ -25,3 +25,11 @@ USERCTL=no
 ONBOOT={{ item.onboot|default("yes") }}
 BOOTPROTO=dhcp
 {% endif %}
+
+{% if item.nm_controlled is defined %}
+NM_CONTROLLED={{ item.nm_controlled }}
+{% endif %}
+
+{% if item.defroute is defined %}
+DEFROUTE={{ item.defroute }}
+{% endif %}

--- a/templates/bond_RedHat.j2
+++ b/templates/bond_RedHat.j2
@@ -47,3 +47,6 @@ BONDING_MASTER={{ item.bonding_master }}
 {% if item.bridge is defined %}
 BRIDGE={{ item.bridge }}
 {% endif %}
+{%- if item.zone is defined -%}
+ZONE={{ item.zone }}
+{% endif %}

--- a/templates/bond_RedHat.j2
+++ b/templates/bond_RedHat.j2
@@ -36,6 +36,9 @@ DEFROUTE={{ item.defroute }}
 {% if item.mtu is defined %}
 MTU={{ item.mtu }}
 {% endif %}
+{%- if item.zeroconf is defined -%}
+NOZEROCONF={{ item.zeroconf }}
+{% endif %}
 
 {% if item.bonding_master is defined %}
 BONDING_MASTER={{ item.bonding_master }}

--- a/templates/bond_slave_RedHat.j2
+++ b/templates/bond_slave_RedHat.j2
@@ -5,6 +5,10 @@ ONBOOT=yes
 SLAVE=yes
 USERCTL=no
 
+{% if item.0.bond_slave_vlan is defined %}
+VLAN=yes
+{% endif %}
+
 {% if item.nm_controlled is defined %}
 NM_CONTROLLED={{ item.nm_controlled }}
 {% endif %}

--- a/templates/bond_slave_RedHat.j2
+++ b/templates/bond_slave_RedHat.j2
@@ -5,3 +5,10 @@ ONBOOT=yes
 SLAVE=yes
 USERCTL=no
 
+{% if item.nm_controlled is defined %}
+NM_CONTROLLED={{ item.nm_controlled }}
+{% endif %}
+
+{% if item.defroute is defined %}
+DEFROUTE={{ item.defroute }}
+{% endif %}

--- a/templates/bond_slave_RedHat.j2
+++ b/templates/bond_slave_RedHat.j2
@@ -5,14 +5,13 @@ ONBOOT=yes
 SLAVE=yes
 USERCTL=no
 
-{% if item.0.bond_slave_vlan is defined %}
-VLAN=yes
-{% endif %}
-
 {% if item.nm_controlled is defined %}
 NM_CONTROLLED={{ item.nm_controlled }}
 {% endif %}
 
 {% if item.defroute is defined %}
 DEFROUTE={{ item.defroute }}
+{% endif %}
+{%- if item.0.bond_slave_vlan is defined -%}
+VLAN=yes
 {% endif %}

--- a/templates/bonding.conf.j2
+++ b/templates/bonding.conf.j2
@@ -1,1 +1,2 @@
-options bonding
+# {{ ansible_managed }}
+options bonding {{ network_extra_bonding_module_options }}

--- a/templates/bridge_Debian.j2
+++ b/templates/bridge_Debian.j2
@@ -10,27 +10,26 @@ netmask {{ item.netmask }}
 {% if item.gateway is defined %}
 gateway {{ item.gateway }}
 {% endif %}
-{% if item.ports is defined %}        
+{% if item.ports is defined %}
 bridge_ports {{ item.ports|join(' ') }}
 {% endif %}
-{% if item.stp is defined %}        
+{% if item.stp is defined %}
 bridge_stp {{ item.stp }}
 {% endif %}
 {% endif %}
 
 {% if item.bootproto == 'dhcp' %}
 iface {{ item.device }}  inet dhcp
-{% if item.ports is defined %}        
+{% if item.ports is defined %}
 bridge_ports {{ item.port }}
 {% endif %}
-{% if item.stp is defined %}        
+{% if item.stp is defined %}
 bridge_stp {{ item.stp }}
 {% endif %}
 {% endif %}
 
 {% if item.route is defined %}
 {% for i in item.route %}
-up route add -net {{ i.network }}  netmask {{ i.netmask }} gw {{ i.gateway }} dev {{ item.device }}
+up route add -net {{ i.network }} netmask {{ i.netmask }} gw {{ i.gateway }} dev {{ item.device }}
 {% endfor %}
 {% endif %}
-

--- a/templates/bridge_RedHat.j2
+++ b/templates/bridge_RedHat.j2
@@ -63,3 +63,9 @@ BRIDGING_OPTS="{{ item.bridging_opts }}"
 {%- if item.zone is defined -%}
 ZONE={{ item.zone }}
 {% endif %}
+{%- if item.dns1 is defined -%}
+DNS1={{ item.dns1 }}
+{% endif %}
+{%- if item.dns2 is defined -%}
+DNS2={{ item.dns2 }}
+{% endif %}

--- a/templates/bridge_RedHat.j2
+++ b/templates/bridge_RedHat.j2
@@ -54,3 +54,6 @@ DEFROUTE={{ item.defroute }}
 {%- if item.mtu is defined -%}
 MTU={{ item.mtu }}
 {% endif %}
+{%- if item.zeroconf is defined -%}
+NOZEROCONF={{ item.zeroconf }}
+{% endif %}

--- a/templates/bridge_RedHat.j2
+++ b/templates/bridge_RedHat.j2
@@ -28,3 +28,11 @@ BOOTPROTO=dhcp
 STP={{ item.stp }}
 {% endif %}
 {% endif %}
+
+{% if item.nm_controlled is defined %}
+NM_CONTROLLED={{ item.nm_controlled }}
+{% endif %}
+
+{% if item.defroute is defined %}
+DEFROUTE={{ item.defroute }}
+{% endif %}

--- a/templates/bridge_RedHat.j2
+++ b/templates/bridge_RedHat.j2
@@ -60,3 +60,6 @@ NOZEROCONF={{ item.nozeroconf }}
 {%- if item.bridging_opts is defined -%}
 BRIDGING_OPTS="{{ item.bridging_opts }}"
 {% endif %}
+{%- if item.zone is defined -%}
+ZONE={{ item.zone }}
+{% endif %}

--- a/templates/bridge_RedHat.j2
+++ b/templates/bridge_RedHat.j2
@@ -54,6 +54,6 @@ DEFROUTE={{ item.defroute }}
 {%- if item.mtu is defined -%}
 MTU={{ item.mtu }}
 {% endif %}
-{%- if item.zeroconf is defined -%}
-NOZEROCONF={{ item.zeroconf }}
+{%- if item.nozeroconf is defined -%}
+NOZEROCONF={{ item.nozeroconf }}
 {% endif %}

--- a/templates/bridge_RedHat.j2
+++ b/templates/bridge_RedHat.j2
@@ -1,21 +1,20 @@
-
 {% if item.bootproto == 'static' %}
 DEVICE={{ item.device }}
 TYPE=Bridge
 BOOTPROTO=none
-{% if item.stp is defined %}
+{% if item.stp is defined -%}
 STP={{ item.stp }}
 {% endif %}
-{% if item.address is defined %}
+{%- if item.address is defined -%}
 IPADDR={{ item.address }}
 {% endif %}
-{% if item.onboot is defined %}
+{%- if item.onboot is defined -%}
 ONBOOT={{ item.onboot }}
 {% endif %}
-{% if item.netmask is defined %}
+{%- if item.netmask is defined -%}
 NETMASK={{ item.netmask }}
 {% endif %}
-{% if item.gateway is defined %}
+{%- if item.gateway is defined -%}
 GATEWAY={{ item.gateway }}
 {% endif %}
 {% endif %}
@@ -24,16 +23,16 @@ GATEWAY={{ item.gateway }}
 DEVICE={{ item.device }}
 TYPE=bridge
 BOOTPROTO=dhcp
-{% if item.stp is defined %}
+{% if item.stp is defined -%}
 STP={{ item.stp }}
 {% endif %}
 {% endif %}
 
-{% if item.nm_controlled is defined %}
+{%- if item.nm_controlled is defined -%}
 NM_CONTROLLED={{ item.nm_controlled }}
 {% endif %}
 
-{% if item.ipv6_address is defined %}
+{%- if item.ipv6_address is defined -%}
 IPV6INIT="yes"
 IPV6_AUTOCONF="yes"
 IPV6_DEFROUTE="yes"
@@ -44,15 +43,14 @@ IPV6_PEERROUTES="yes"
 IPV6_PRIVACY="no"
 IPV6ADDR={{ item.ipv6_address }}
 {% endif %}
-{% if item.ipv6_gateway is defined %}
+{%- if item.ipv6_gateway is defined -%}
 IPV6_DEFAULTGW="{{ item.ipv6_gateway }}"
 {% endif %}
 
-
-{% if item.defroute is defined %}
+{%- if item.defroute is defined -%}
 DEFROUTE={{ item.defroute }}
 {% endif %}
 
-{% if item.mtu is defined %}
+{%- if item.mtu is defined -%}
 MTU={{ item.mtu }}
 {% endif %}

--- a/templates/bridge_RedHat.j2
+++ b/templates/bridge_RedHat.j2
@@ -33,6 +33,22 @@ STP={{ item.stp }}
 NM_CONTROLLED={{ item.nm_controlled }}
 {% endif %}
 
+{% if item.ipv6_address is defined %}
+IPV6INIT="yes"
+IPV6_AUTOCONF="yes"
+IPV6_DEFROUTE="yes"
+IPV6_FAILURE_FATAL="no"
+IPV6_FORWARDING="yes"
+IPV6_PEERDNS="yes"
+IPV6_PEERROUTES="yes"
+IPV6_PRIVACY="no"
+IPV6ADDR={{ item.ipv6_address }}
+{% endif %}
+{% if item.ipv6_gateway is defined %}
+IPV6_DEFAULTGW="{{ item.ipv6_gateway }}"
+{% endif %}
+
+
 {% if item.defroute is defined %}
 DEFROUTE={{ item.defroute }}
 {% endif %}

--- a/templates/bridge_RedHat.j2
+++ b/templates/bridge_RedHat.j2
@@ -36,3 +36,7 @@ NM_CONTROLLED={{ item.nm_controlled }}
 {% if item.defroute is defined %}
 DEFROUTE={{ item.defroute }}
 {% endif %}
+
+{% if item.mtu is defined %}
+MTU={{ item.mtu }}
+{% endif %}

--- a/templates/bridge_RedHat.j2
+++ b/templates/bridge_RedHat.j2
@@ -57,3 +57,6 @@ MTU={{ item.mtu }}
 {%- if item.nozeroconf is defined -%}
 NOZEROCONF={{ item.nozeroconf }}
 {% endif %}
+{%- if item.bridging_opts is defined -%}
+BRIDGING_OPTS="{{ item.bridging_opts }}"
+{% endif %}

--- a/templates/bridge_port_Debian.j2
+++ b/templates/bridge_port_Debian.j2
@@ -1,2 +1,2 @@
 auto {{ item.1 }}
-iface {{ item.1 }}  inet manual
+iface {{ item.1 }} inet manual

--- a/templates/bridge_port_RedHat.j2
+++ b/templates/bridge_port_RedHat.j2
@@ -1,6 +1,4 @@
-
 DEVICE={{ item.1 }}
 TYPE=Ethernet
 BOOTPROTO=none
 BRIDGE={{ item.0.device }}
-

--- a/templates/ethernet_RedHat.j2
+++ b/templates/ethernet_RedHat.j2
@@ -52,3 +52,6 @@ DEFROUTE={{ item.defroute }}
 {%- if item.mtu is defined -%}
 MTU={{ item.mtu }}
 {% endif %}
+{%- if item.zeroconf is defined -%}
+NOZEROCONF={{ item.zeroconf }}
+{% endif %}

--- a/templates/ethernet_RedHat.j2
+++ b/templates/ethernet_RedHat.j2
@@ -14,9 +14,20 @@ NETMASK={{ item.netmask }}
 {% if item.gateway is defined %}
 GATEWAY={{ item.gateway }}
 {% endif %}
+{% if item.vlan is defined %}
+VLAN=yes
+{% endif %}
 {% endif %}
 
 {% if item.bootproto == 'dhcp' %}
 DEVICE={{ item.device }}
 BOOTPROTO=dhcp
+{% endif %}
+
+{% if item.nm_controlled is defined %}
+NM_CONTROLLED={{ item.nm_controlled }}
+{% endif %}
+
+{% if item.defroute is defined %}
+DEFROUTE={{ item.defroute }}
 {% endif %}

--- a/templates/ethernet_RedHat.j2
+++ b/templates/ethernet_RedHat.j2
@@ -28,6 +28,21 @@ BOOTPROTO=dhcp
 NM_CONTROLLED={{ item.nm_controlled }}
 {% endif %}
 
+{% if item.ipv6_address is defined %}
+IPV6INIT="yes"
+IPV6_AUTOCONF="yes"
+IPV6_DEFROUTE="yes"
+IPV6_FAILURE_FATAL="no"
+IPV6_FORWARDING="yes"
+IPV6_PEERDNS="yes"
+IPV6_PEERROUTES="yes"
+IPV6_PRIVACY="no"
+IPV6ADDR={{ item.ipv6_address }}
+{% endif %}
+{% if item.ipv6_gateway is defined %}
+IPV6_DEFAULTGW="{{ item.ipv6_gateway }}"
+{% endif %}
+
 {% if item.defroute is defined %}
 DEFROUTE={{ item.defroute }}
 {% endif %}

--- a/templates/ethernet_RedHat.j2
+++ b/templates/ethernet_RedHat.j2
@@ -55,3 +55,6 @@ MTU={{ item.mtu }}
 {%- if item.nozeroconf is defined -%}
 NOZEROCONF={{ item.nozeroconf }}
 {% endif %}
+{%- if item.zone is defined -%}
+ZONE={{ item.zone }}
+{% endif %}

--- a/templates/ethernet_RedHat.j2
+++ b/templates/ethernet_RedHat.j2
@@ -58,3 +58,9 @@ NOZEROCONF={{ item.nozeroconf }}
 {%- if item.zone is defined -%}
 ZONE={{ item.zone }}
 {% endif %}
+{%- if item.dns1 is defined -%}
+DNS1={{ item.dns1 }}
+{% endif %}
+{%- if item.dns2 is defined -%}
+DNS2={{ item.dns2 }}
+{% endif %}

--- a/templates/ethernet_RedHat.j2
+++ b/templates/ethernet_RedHat.j2
@@ -1,20 +1,19 @@
-
 {% if item.bootproto == 'static' %}
 DEVICE={{ item.device }}
 BOOTPROTO=none
-{% if item.address is defined %}
+{% if item.address is defined -%}
 IPADDR={{ item.address }}
 {% endif %}
-{% if item.onboot is defined %}
+{%- if item.onboot is defined -%}
 ONBOOT={{ item.onboot }}
 {% endif %}
-{% if item.netmask is defined %}
+{%- if item.netmask is defined -%}
 NETMASK={{ item.netmask }}
 {% endif %}
-{% if item.gateway is defined %}
+{%- if item.gateway is defined -%}
 GATEWAY={{ item.gateway }}
 {% endif %}
-{% if item.vlan is defined %}
+{%- if item.vlan is defined -%}
 VLAN=yes
 {% endif %}
 {% endif %}
@@ -24,11 +23,11 @@ DEVICE={{ item.device }}
 BOOTPROTO=dhcp
 {% endif %}
 
-{% if item.nm_controlled is defined %}
+{%- if item.nm_controlled is defined -%}
 NM_CONTROLLED={{ item.nm_controlled }}
 {% endif %}
 
-{% if item.ipv6_address is defined %}
+{%- if item.ipv6_address is defined -%}
 IPV6INIT="yes"
 IPV6_AUTOCONF="yes"
 IPV6_DEFROUTE="yes"
@@ -39,14 +38,14 @@ IPV6_PEERROUTES="yes"
 IPV6_PRIVACY="no"
 IPV6ADDR={{ item.ipv6_address }}
 {% endif %}
-{% if item.ipv6_gateway is defined %}
+{%- if item.ipv6_gateway is defined -%}
 IPV6_DEFAULTGW="{{ item.ipv6_gateway }}"
 {% endif %}
 
-{% if item.defroute is defined %}
+{%- if item.defroute is defined -%}
 DEFROUTE={{ item.defroute }}
 {% endif %}
 
-{% if item.mtu is defined %}
+{%- if item.mtu is defined -%}
 MTU={{ item.mtu }}
 {% endif %}

--- a/templates/ethernet_RedHat.j2
+++ b/templates/ethernet_RedHat.j2
@@ -52,6 +52,6 @@ DEFROUTE={{ item.defroute }}
 {%- if item.mtu is defined -%}
 MTU={{ item.mtu }}
 {% endif %}
-{%- if item.zeroconf is defined -%}
-NOZEROCONF={{ item.zeroconf }}
+{%- if item.nozeroconf is defined -%}
+NOZEROCONF={{ item.nozeroconf }}
 {% endif %}

--- a/templates/ethernet_RedHat.j2
+++ b/templates/ethernet_RedHat.j2
@@ -1,5 +1,5 @@
 
-{% if item.bootproto == 'static' %}
+{% if item.bootproto == 'static' or item.bootproto == 'none' %}
 DEVICE={{ item.device }}
 BOOTPROTO=none
 {% if item.address is defined %}
@@ -16,6 +16,9 @@ GATEWAY={{ item.gateway }}
 {% endif %}
 {% if item.vlan is defined %}
 VLAN=yes
+{% endif %}
+{%- if item.bridge is defined -%}
+BRIDGE={{ item.bridge }}
 {% endif %}
 {% endif %}
 

--- a/templates/ethernet_RedHat.j2
+++ b/templates/ethernet_RedHat.j2
@@ -31,3 +31,7 @@ NM_CONTROLLED={{ item.nm_controlled }}
 {% if item.defroute is defined %}
 DEFROUTE={{ item.defroute }}
 {% endif %}
+
+{% if item.mtu is defined %}
+MTU={{ item.mtu }}
+{% endif %}

--- a/templates/ethernet_RedHat.j2
+++ b/templates/ethernet_RedHat.j2
@@ -33,15 +33,15 @@ NM_CONTROLLED={{ item.nm_controlled }}
 {%- if item.ipv6_address is defined -%}
 IPV6INIT="yes"
 IPV6_AUTOCONF="yes"
-IPV6_DEFROUTE="yes"
 IPV6_FAILURE_FATAL="no"
-IPV6_FORWARDING="yes"
-IPV6_PEERDNS="yes"
-IPV6_PEERROUTES="yes"
 IPV6_PRIVACY="no"
 IPV6ADDR={{ item.ipv6_address }}
 {% endif %}
 {%- if item.ipv6_gateway is defined -%}
+IPV6_FORWARDING="yes"
+IPV6_PEERDNS="yes"
+IPV6_PEERROUTES="yes"
+IPV6_DEFROUTE="yes"
 IPV6_DEFAULTGW="{{ item.ipv6_gateway }}"
 {% endif %}
 

--- a/templates/route_Debian.j2
+++ b/templates/route_Debian.j2
@@ -1,4 +1,3 @@
 {% for i in item.route %}
-up route add -net {{ i.network }}  netmask {{ i.netmask }} gw {{ i.gateway }} dev {{ item.device }} 
+up route add -net {{ i.network }} netmask {{ i.netmask }} gw {{ i.gateway }} dev {{ item.device }}
 {% endfor %}
-

--- a/templates/route_RedHat.j2
+++ b/templates/route_RedHat.j2
@@ -1,6 +1,8 @@
 {% for i in item.route %}
 ADDRESS{{ loop.index - 1  }}={{ i.network }}
 NETMASK{{ loop.index - 1 }}={{ i.netmask }}
+{% if i.gateway is defined %}
 GATEWAY{{ loop.index - 1 }}={{ i.gateway }}
+{% endif %}
 {% endfor %}
 

--- a/templates/route_RedHat.j2
+++ b/templates/route_RedHat.j2
@@ -5,4 +5,3 @@ NETMASK{{ loop.index - 1 }}={{ i.netmask }}
 GATEWAY{{ loop.index - 1 }}={{ i.gateway }}
 {% endif %}
 {% endfor %}
-

--- a/tests/ansible-min-version-centos7/Dockerfile
+++ b/tests/ansible-min-version-centos7/Dockerfile
@@ -1,0 +1,24 @@
+# Latest version of centos
+FROM centos:centos7
+MAINTAINER James Cuzella <james.cuzella@lyraphase.com>
+RUN yum clean all && \
+    yum -y install epel-release && \
+    yum -y groupinstall "Development tools" && \
+    yum -y install python-devel MySQL-python sshpass && \
+    yum -y install acl sudo && \
+    sed -i -e 's/^Defaults.*requiretty/Defaults    !requiretty/' -e 's/^%wheel.*ALL$/%wheel    ALL=(ALL)    NOPASSWD: ALL/' /etc/sudoers && \
+    yum -y install PyYAML python-jinja2 python-httplib2 python-keyczar python-paramiko python-setuptools git python-pip \
+    pip install pyrax pysphere boto passlib dnspython && \
+    yum -y remove $(rpm -qa "*-devel") && \
+    yum -y groupremove "Development tools" && \
+    yum -y autoremove && \
+    yum -y install bzip2 file findutils gem git gzip hg procps-ng svn sudo tar tree which unzip xz zip
+
+RUN mkdir /etc/ansible/
+RUN echo -e '[local]\nlocalhost' > /etc/ansible/hosts
+# Not installing ansible in the Dockerbuild phase
+#  instead for this Dockerfile we outside ask the ansible-role which
+#  is the minimum supported ansible version and install that.
+#RUN pip install ansible==2.2.3.0
+
+CMD ["/bin/bash"]

--- a/tests/devel-centos7/Dockerfile
+++ b/tests/devel-centos7/Dockerfile
@@ -1,0 +1,41 @@
+# Latest version of centos
+FROM centos:centos7
+MAINTAINER James Cuzella <james.cuzella@lyraphase.com>
+RUN yum clean all && \
+    yum -y install epel-release && \
+    yum makecache all && \
+    yum -y groups mark convert && \
+    yum -y groups mark install "Development Tools" && \
+    yum -y groups mark convert "Development Tools" && \
+    yum -y groupinstall "Development Tools" && \
+    yum -y install libffi-devel openssl-devel && \
+    yum -y install python-devel MySQL-python sshpass && \
+    yum -y install acl sudo && \
+    sed -i -e 's/^Defaults.*requiretty/Defaults    !requiretty/' -e 's/^%wheel.*ALL$/%wheel    ALL=(ALL)    NOPASSWD: ALL/' /etc/sudoers && \
+    yum -y install PyYAML python-jinja2 python-httplib2 python-keyczar python-paramiko python-setuptools git python-pip && \
+    pip install --upgrade pip && \
+    pip install requests[security] && \
+    pip install pyrax pysphere boto boto3 passlib dnspython && \
+    sh -c 'yum -y remove libffi-devel || yum -y --setopt=tsflags=noscripts remove libffi-devel' && \
+    yum -y remove $(rpm -qa "*-devel") && \
+    yum -y groupremove "Development tools" && \
+    yum -y autoremove && \
+    yum -y install bzip2 crontabs file findutils gem git gzip hg hostname procps-ng svn sudo tar tree which unzip xz zip && \
+    yum clean all && rm -rf /var/cache/yum
+
+RUN mkdir /etc/ansible/
+RUN echo -e '[local]\nlocalhost\n' > /etc/ansible/hosts
+RUN mkdir /opt/ansible/
+RUN git clone http://github.com/ansible/ansible.git /opt/ansible/ansible
+WORKDIR /opt/ansible/ansible
+RUN git submodule update --init
+ENV PATH /opt/ansible/ansible/bin:/bin:/usr/bin:/sbin:/usr/sbin
+ENV PYTHONPATH /opt/ansible/ansible/lib
+ENV ANSIBLE_LIBRARY /opt/ansible/ansible/library
+# Workaround bug in pip / pylockfile: http://pad.lv/1472101
+# If HOME is a volume mount, causes infinite loop in pip trying to write lock
+ENV XDG_CACHE_HOME /tmp/
+RUN source /opt/ansible/ansible/hacking/env-setup
+
+
+CMD /bin/bash

--- a/tests/devel-centos7/Dockerfile
+++ b/tests/devel-centos7/Dockerfile
@@ -13,9 +13,9 @@ RUN yum clean all && \
     yum -y install acl sudo && \
     sed -i -e 's/^Defaults.*requiretty/Defaults    !requiretty/' -e 's/^%wheel.*ALL$/%wheel    ALL=(ALL)    NOPASSWD: ALL/' /etc/sudoers && \
     yum -y install PyYAML python-jinja2 python-httplib2 python-keyczar python-paramiko python-setuptools git python-pip && \
-    pip install --upgrade pip && \
+    pip install --upgrade --force-reinstall pip==9.0.3 && \
     pip install requests[security] && \
-    pip install pyrax pysphere boto boto3 passlib dnspython && \
+    pip install passlib dnspython && \
     sh -c 'yum -y remove libffi-devel || yum -y --setopt=tsflags=noscripts remove libffi-devel' && \
     yum -y remove $(rpm -qa "*-devel") && \
     yum -y groupremove "Development tools" && \

--- a/tests/inventory
+++ b/tests/inventory
@@ -1,0 +1,4 @@
+localhost
+
+[login]
+localhost

--- a/tests/stable-centos7/Dockerfile
+++ b/tests/stable-centos7/Dockerfile
@@ -1,0 +1,21 @@
+# Latest version of centos
+FROM centos:centos7
+MAINTAINER James Cuzella <james.cuzella@lyraphase.com>
+RUN yum clean all && \
+    yum -y install epel-release && \
+    yum -y groupinstall "Development tools" && \
+    yum -y install python-devel MySQL-python sshpass && \
+    yum -y install acl sudo && \
+    sed -i -e 's/^Defaults.*requiretty/Defaults    !requiretty/' -e 's/^%wheel.*ALL$/%wheel    ALL=(ALL)    NOPASSWD: ALL/' /etc/sudoers && \
+    yum -y install PyYAML python-jinja2 python-httplib2 python-keyczar python-paramiko python-setuptools git python-pip \
+    pip install pyrax pysphere boto passlib dnspython && \
+    yum -y remove $(rpm -qa "*-devel") && \
+    yum -y groupremove "Development tools" && \
+    yum -y autoremove && \
+    yum -y install bzip2 crontabs file findutils gem git gzip hg hostname procps-ng svn sudo tar tree which unzip xz zip
+
+RUN mkdir /etc/ansible/
+RUN echo -e '[local]\nlocalhost' > /etc/ansible/hosts
+RUN pip install ansible
+
+CMD ["/bin/bash"]

--- a/tests/test-in-docker-image.sh
+++ b/tests/test-in-docker-image.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+
+SOURCE="${BASH_SOURCE[0]}"
+RDIR="$( dirname "$SOURCE" )"
+SUDO=`which sudo 2> /dev/null`
+SUDO_OPTION=""
+#SUDO_OPTION="--sudo"
+OS_TYPE=${1:-}
+OS_VERSION=${2:-}
+ANSIBLE_VERSION=${3:-}
+
+ANSIBLE_VAR=""
+ANSIBLE_INVENTORY="tests/inventory"
+ANSIBLE_PLAYBOOk="tests/test.yml"
+#ANSIBLE_LOG_LEVEL=""
+ANSIBLE_LOG_LEVEL="-v"
+APACHE_CTL="apache2ctl"
+
+# if there wasn't sudo then ansible couldn't use it
+if [ "x$SUDO" == "x" ];then
+    SUDO_OPTION=""
+fi
+
+if [ "${OS_TYPE}" == "stable-centos7-puppet5" ];then
+  echo "TEST: set tests/test5.yml as playbook"
+  ANSIBLE_PLAYBOOk="tests/test5.yml"
+fi
+
+ANSIBLE_EXTRA_VARS=""
+if [ "${ANSIBLE_VAR}x" == "x" ];then
+    ANSIBLE_EXTRA_VARS=" -e \"${ANSIBLE_VAR}\" "
+fi
+
+
+cd $RDIR/..
+printf "[defaults]\nroles_path = ../:roles\ncallback_whitelist = profile_tasks" > ansible.cfg
+printf "" > ssh.config
+
+function show_version() {
+
+echo "TEST: show versions"
+ansible --version
+id
+systemctl --no-pager
+proc1comm=$(cat /proc/1/comm)
+echo "TEST: proc1s comm is $proc1comm"
+
+}
+
+function install_ansible_devel() {
+
+# http://docs.ansible.com/ansible/intro_installation.html#latest-release-via-yum
+
+echo "TEST: building ansible"
+
+yum -y install PyYAML python-paramiko python-jinja2 python-httplib2 rpm-build make python2-devel asciidoc patch wget 2>&1 >/dev/null || (echo "Could not install ansible yum dependencies" && exit 2 )
+rm -Rf ansible
+git clone https://github.com/ansible/ansible --recursive ||(echo "Could not clone ansible from Github" && exit 2 )
+cd ansible
+# checking out this commit because some errors after 2015-11-05
+#git checkout 07d0d2720c73816e1206882db7bc856087eb5c3f
+# because systemctl and systemd
+git checkout 589971fe7ef78ea8bb41fb9ae6cd19cb8e277371
+make rpm 2>&1 >/dev/null
+rpm -Uvh ./rpm-build/ansible-*.noarch.rpm ||(echo "Could not install built ansible devel rpms" && exit 2 )
+cd ..
+rm -Rf ansible
+
+}
+
+function install_os_deps() {
+echo "TEST: installing os deps"
+
+yum -y install epel-release sudo tree git which file less||(echo "Could not install some os deps" && exit 2 )
+
+}
+
+function tree_list() {
+
+tree
+
+}
+function test_ansible_setup(){
+    echo "TEST: ansible -m setup -i ${ANSIBLE_INVENTORY} --connection=local localhost"
+
+    ansible -m setup -i ${ANSIBLE_INVENTORY} --connection=local localhost
+
+}
+
+
+function test_install_requirements(){
+    echo "TEST: ansible-galaxy install -r requirements.yml --force"
+
+    ansible-galaxy install -r requirements.yml --force ||(echo "requirements install failed" && exit 2 )
+
+}
+
+function test_playbook_syntax(){
+    echo "TEST: ansible-playbook -i ${ANSIBLE_INVENTORY} ${ANSIBLE_PLAYBOOk} --syntax-check"
+
+    ansible-playbook -i ${ANSIBLE_INVENTORY} ${ANSIBLE_PLAYBOOk} --syntax-check ||(echo "ansible playbook syntax check was failed" && exit 2 )
+}
+
+function test_playbook_check(){
+    echo "TEST: ansible-playbook -i ${ANSIBLE_INVENTORY} ${ANSIBLE_PLAYBOOk} ${ANSIBLE_LOG_LEVEL} --connection=local ${SUDO_OPTION} ${ANSIBLE_EXTRA_VARS} --check"
+
+    ansible-playbook -i ${ANSIBLE_INVENTORY} ${ANSIBLE_PLAYBOOk} ${ANSIBLE_LOG_LEVEL} --connection=local ${SUDO_OPTION} ${ANSIBLE_EXTRA_VARS} --check ||(echo "playbook check failed" && exit 2 )
+
+
+}
+
+function test_playbook(){
+    echo "TEST: ansible-playbook -i ${ANSIBLE_INVENTORY} ${ANSIBLE_PLAYBOOk} ${ANSIBLE_LOG_LEVEL} --connection=local ${SUDO_OPTION} ${ANSIBLE_EXTRA_VARS}"
+
+    ansible-playbook -i ${ANSIBLE_INVENTORY} ${ANSIBLE_PLAYBOOk} ${ANSIBLE_LOG_LEVEL} --connection=local ${SUDO_OPTION} ${ANSIBLE_EXTRA_VARS} ||(echo "first ansible run failed" && exit 2 )
+
+
+#    echo "TEST: idempotence test! Same as previous but now grep for changed=0.*failed=0"
+#    ansible-playbook -i ${ANSIBLE_INVENTORY} ${ANSIBLE_PLAYBOOk} ${ANSIBLE_LOG_LEVEL} --connection=local ${SUDO_OPTION} ${ANSIBLE_EXTRA_VARS} || grep -q 'changed=0.*failed=0' && (echo 'Idempotence test: pass' ) || (echo 'Idempotence test: fail' && exit 1)
+}
+function extra_tests(){
+
+    echo "TEST: ls /etc/puppet/*"
+    ls /etc/puppet/
+
+}
+
+
+set -e
+function main(){
+#    install_os_deps
+#    install_ansible_devel
+#    show_version
+#    tree_list
+#    test_install_requirements
+    test_ansible_setup
+    test_playbook_syntax
+    test_playbook
+    test_playbook_check
+#    extra_tests
+
+}
+
+################ run #########################
+main

--- a/tests/test-in-docker-image.sh
+++ b/tests/test-in-docker-image.sh
@@ -40,10 +40,6 @@ function show_version() {
 
 echo "TEST: show versions"
 ansible --version
-id
-systemctl --no-pager
-proc1comm=$(cat /proc/1/comm)
-echo "TEST: proc1s comm is $proc1comm"
 
 }
 
@@ -130,7 +126,7 @@ set -e
 function main(){
 #    install_os_deps
 #    install_ansible_devel
-#    show_version
+    show_version
 #    tree_list
 #    test_install_requirements
     test_ansible_setup

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,0 +1,7 @@
+---
+
+ - hosts: localhost
+   remote_user: root
+   roles:
+     - network_interface
+...

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -4,4 +4,9 @@ network_pkgs:
   - bridge-utils
   - iputils
 
+network_pkgs_centos8:
+  - python3-libselinux
+  - bridge-utils
+  - iputils
+
 net_path: "/etc/sysconfig/network-scripts"

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -4,7 +4,7 @@ network_pkgs:
   - bridge-utils
   - iputils
 
-network_pkgs_centos8:
+network_pkgs_rhel8_9based:
   - python3-libselinux
   - bridge-utils
   - iputils


### PR DESCRIPTION
Reapplying non-bond interfaces was added because routes were not applied
on them. Bond interfaces are created when role is being applied which is
why they could be ignored on this task.